### PR TITLE
Xstream keeps path references to unreferenceable objects

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/XStream.java
+++ b/xstream/src/java/com/thoughtworks/xstream/XStream.java
@@ -871,39 +871,37 @@ public class XStream {
         }
 
         // primitives are always immutable
-        addImmutableType(boolean.class);
-        addImmutableType(Boolean.class);
-        addImmutableType(byte.class);
-        addImmutableType(Byte.class);
-        addImmutableType(char.class);
-        addImmutableType(Character.class);
-        addImmutableType(double.class);
-        addImmutableType(Double.class);
-        addImmutableType(float.class);
-        addImmutableType(Float.class);
-        addImmutableType(int.class);
-        addImmutableType(Integer.class);
-        addImmutableType(long.class);
-        addImmutableType(Long.class);
-        addImmutableType(short.class);
-        addImmutableType(Short.class);
+        addImmutableType(boolean.class, false);
+        addImmutableType(Boolean.class, false);
+        addImmutableType(byte.class, false);
+        addImmutableType(Byte.class, false);
+        addImmutableType(char.class, false);
+        addImmutableType(double.class, false);
+        addImmutableType(Double.class, false);
+        addImmutableType(float.class, false);
+        addImmutableType(Float.class, false);
+        addImmutableType(int.class, false);
+        addImmutableType(Integer.class, false);
+        addImmutableType(long.class, false);
+        addImmutableType(Long.class, false);
+        addImmutableType(short.class, false);
+        addImmutableType(Short.class, false);
 
         // additional types
-        addImmutableType(Mapper.Null.class);
-        addImmutableType(BigDecimal.class);
-        addImmutableType(BigInteger.class);
-        addImmutableType(String.class);
-        addImmutableType(Charset.class);
-        addImmutableType(Currency.class);
-        addImmutableType(URI.class);
-        addImmutableType(URL.class);
-        addImmutableType(File.class);
-        addImmutableType(Class.class);
-        addImmutableType(UUID.class);
-
-        addImmutableType(Collections.EMPTY_LIST.getClass());
-        addImmutableType(Collections.EMPTY_SET.getClass());
-        addImmutableType(Collections.EMPTY_MAP.getClass());
+        addImmutableType(Charset.class, true);
+        addImmutableType(UUID.class, true);
+        addImmutableType(Currency.class, true);
+        addImmutableType(Mapper.Null.class, false);
+        addImmutableType(BigDecimal.class, false);
+        addImmutableType(BigInteger.class, false);
+        addImmutableType(String.class, false);
+        addImmutableType(URI.class, false);
+        addImmutableType(URL.class, false);
+        addImmutableType(File.class, false);
+        addImmutableType(Class.class, false);
+        addImmutableType(Collections.EMPTY_LIST.getClass(), false);
+        addImmutableType(Collections.EMPTY_SET.getClass(), false);
+        addImmutableType(Collections.EMPTY_MAP.getClass(), false);
 
         if (JVM.isAWTAvailable()) {
             addImmutableTypeDynamically("java.awt.font.TextAttribute");
@@ -1328,16 +1326,42 @@ public class XStream {
     }
 
     /**
-     * Add immutable types. The value of the instances of these types will always be written into the stream even if
-     * they appear multiple times.
-     * 
+     * Register an immutable type. Instances of immutable types will always be written
+     * into the stream (as a full document instead of a reference) even if they appear multiple times.
+     *
+     * <p>A reference map will be built at unmarshalling time anyways so that documents of an
+     * earlier version (where the <tt>type</tt> was <i>not</i> registered as immutable) will
+     * still be deserialized properly. Use {@link #addImmutableType(Class, boolean)}
+     * if this is not desired.
+     *
      * @throws InitializationException if no {@link ImmutableTypesMapper} is available
+     * @throws IllegalArgumentException if <code>type</code> is <tt>null</tt>
      */
     public void addImmutableType(final Class<?> type) {
+        addImmutableType(type, true);
+    }
+
+    /**
+     * Register an immutable type. Instances of immutable types will always be written
+     * into the stream (as a full document instead of a reference) even if they appear multiple times.
+     *
+     * <p>Documents containing reference-paths to the specified immutable type will continue to
+     * deserialize if <code>isReferenceable</code> is <tt>true</tt>, else no reference paths
+     * will be kept as the document is unmarshalled,
+     * saving memory but breaking those existing documents.</p>
+     *
+     * @throws InitializationException if no {@link ImmutableTypesMapper} is available
+     * @throws IllegalArgumentException if <code>type</code> is <tt>null</tt>
+     * @since upcoming
+     */
+    public void addImmutableType(final Class<?> type, final boolean isReferenceable) {
+        if(type == null) { throw new IllegalArgumentException("type"); }
         if (immutableTypesMapper == null) {
-            throw new InitializationException("No " + ImmutableTypesMapper.class.getName() + " available");
+            throw new com.thoughtworks.xstream.InitializationException("No "
+                    + ImmutableTypesMapper.class.getName()
+                    + " available");
         }
-        immutableTypesMapper.addImmutableType(type);
+        immutableTypesMapper.addImmutableType(type, isReferenceable);
     }
 
     /**

--- a/xstream/src/java/com/thoughtworks/xstream/mapper/DefaultMapper.java
+++ b/xstream/src/java/com/thoughtworks/xstream/mapper/DefaultMapper.java
@@ -110,6 +110,11 @@ public class DefaultMapper implements Mapper {
     }
 
     @Override
+    public boolean isReferenceable(final Class<?> type){
+        return true;
+    }
+
+    @Override
     public String getFieldNameForItemTypeAndName(final Class<?> definedIn, final Class<?> itemType,
             final String itemFieldName) {
         return null;

--- a/xstream/src/java/com/thoughtworks/xstream/mapper/ImmutableTypesMapper.java
+++ b/xstream/src/java/com/thoughtworks/xstream/mapper/ImmutableTypesMapper.java
@@ -23,23 +23,25 @@ import java.util.Set;
  */
 public class ImmutableTypesMapper extends MapperWrapper {
 
+    private final Set<Class<?>> unreferenceableTypes = new HashSet<Class<?>>();
     private final Set<Class<?>> immutableTypes = new HashSet<Class<?>>();
 
     public ImmutableTypesMapper(final Mapper wrapped) {
         super(wrapped);
     }
 
-    public void addImmutableType(final Class<?> type) {
+    public void addImmutableType(final Class<?> type, boolean isReferenceable) {
         immutableTypes.add(type);
+        if(! isReferenceable) { unreferenceableTypes.add(type); }
     }
 
     @Override
     public boolean isImmutableValueType(final Class<?> type) {
-        if (immutableTypes.contains(type)) {
-            return true;
-        } else {
-            return super.isImmutableValueType(type);
-        }
+        return immutableTypes.contains(type) || super.isImmutableValueType(type);
     }
 
+    @Override
+    public boolean isReferenceable(final Class<?> type) {
+        return ! unreferenceableTypes.contains(type);
+    }
 }

--- a/xstream/src/java/com/thoughtworks/xstream/mapper/Mapper.java
+++ b/xstream/src/java/com/thoughtworks/xstream/mapper/Mapper.java
@@ -47,6 +47,14 @@ public interface Mapper {
      */
     boolean isImmutableValueType(Class<?> type);
 
+    /**
+     * Whether this type is an immutable type whose references must be kept anyways
+     * (for compatibility) at deserialization.
+     *
+     * @since upcoming
+     */
+    boolean isReferenceable(Class<?> type);
+
     Class<?> defaultImplementationOf(Class<?> type);
 
     /**

--- a/xstream/src/java/com/thoughtworks/xstream/mapper/MapperWrapper.java
+++ b/xstream/src/java/com/thoughtworks/xstream/mapper/MapperWrapper.java
@@ -49,6 +49,11 @@ public abstract class MapperWrapper implements Mapper {
     }
 
     @Override
+    public boolean isReferenceable(Class<?> type) {
+        return wrapped.isReferenceable(type);
+    }
+
+    @Override
     public Class<?> defaultImplementationOf(final Class<?> type) {
         return wrapped.defaultImplementationOf(type);
     }

--- a/xstream/src/test/com/thoughtworks/acceptance/ImmutableRegistryTest.java
+++ b/xstream/src/test/com/thoughtworks/acceptance/ImmutableRegistryTest.java
@@ -1,0 +1,91 @@
+package com.thoughtworks.acceptance;
+
+import com.thoughtworks.acceptance.objects.StandardObject;
+import com.thoughtworks.acceptance.someobjects.WithNamedList;
+import com.thoughtworks.acceptance.someobjects.X;
+import com.thoughtworks.xstream.converters.ConversionException;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Created by Geoff on 2015-04-22.
+ */
+public class ImmutableRegistryTest extends AbstractAcceptanceTest{
+
+    /**
+     * see {@link com.thoughtworks.xstream.XStream#setupImmutableTypes()} for the list
+     * of built-in immutables, note that URL is one of them.
+     */
+    public static class URLPair extends StandardObject{
+        URL source;
+        URL destination;
+
+        public URLPair(URL source, URL destination){
+            this.source = source;
+            this.destination = destination;
+        }
+
+        public URLPair(URL both){
+            this.source = both;
+            this.destination = both;
+        }
+    }
+
+    public void testDocumentWithImmutableMembersDontUseXPathByDefault() throws MalformedURLException{
+        xstream.alias("URLPair", URLPair.class);
+
+        URL empower = new URL("http://www.empoweroperations.com");
+        URLPair pair = new URLPair(empower);
+
+        String expectedXml = "" +
+                 "<URLPair>\n" +
+                 "  <source>http://www.empoweroperations.com</source>\n" +
+                 "  <destination>http://www.empoweroperations.com</destination>\n" +
+                 "</URLPair>";
+
+        assertBothWays(pair, expectedXml);
+    }
+
+    public void testDocumentWithPreviouslyMutableNowImmutableMembersDeserializeOK() throws MalformedURLException{
+        xstream.alias("ThingsDocument", WithNamedList.class);
+        xstream.alias("X", X.class);
+
+        WithNamedList instance = new WithNamedList("Exes");
+        X sharedRef = new X(1);
+        instance.things.add(sharedRef);
+        instance.things.add(sharedRef);
+
+        String serialized = xstream.toXML(instance);
+
+        //act
+        xstream.addImmutableType(X.class);
+        WithNamedList deserialized = (WithNamedList) xstream.fromXML(serialized);
+
+        //assert
+        assertNotNull(deserialized);
+        assertEquals(new X(1), deserialized.things.get(0));
+        assertEquals(new X(1), deserialized.things.get(1));
+        assertSame(deserialized.things.get(0), deserialized.things.get(1));
+        assertEquals(2, deserialized.things.size());
+    }
+
+    public void testDeserializingTypeRegisteredAsImmutableThrowsNiceError() throws MalformedURLException {
+        xstream.alias("URLPair", URLPair.class);
+
+        String problemDocument = "" +
+                 "<URLPair>\n" +
+                 "  <source>http://www.empoweroperations.com</source>\n" +
+                 "  <destination reference=\"../source\">\n" +
+                 "</URLPair>";
+
+        try{
+            xstream.fromXML(problemDocument);
+        }
+        catch(ConversionException e){
+            assertEquals(e.get("class"), "java.net.URL");
+            assertTrue(e.getMessage().contains("Invalid reference"));
+        }
+    }
+
+}

--- a/xstream/src/test/com/thoughtworks/xstream/core/ReferenceByXPathMarshallingStrategyTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/core/ReferenceByXPathMarshallingStrategyTest.java
@@ -13,10 +13,21 @@ package com.thoughtworks.xstream.core;
 
 import com.thoughtworks.acceptance.AbstractAcceptanceTest;
 import com.thoughtworks.acceptance.objects.StandardObject;
+import com.thoughtworks.acceptance.someobjects.WithNamedList;
 import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.ConverterLookup;
+import com.thoughtworks.xstream.core.util.ObjectIdDictionary;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import com.thoughtworks.xstream.io.path.Path;
+import com.thoughtworks.xstream.mapper.Mapper;
 
+import java.lang.reflect.Field;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 
 public class ReferenceByXPathMarshallingStrategyTest extends AbstractAcceptanceTest {
@@ -87,5 +98,154 @@ public class ReferenceByXPathMarshallingStrategyTest extends AbstractAcceptanceT
                 "</list>";
 
         assertBothWays(list, expected);
+    }
+
+    public class CountingXPathStrategy extends ReferenceByXPathMarshallingStrategy{
+
+        public CountingXPathStrategy() {
+            super(ReferenceByXPathMarshallingStrategy.ABSOLUTE);
+        }
+
+        public ReferenceByXPathMarshaller requestedMarshaller;
+        public ReferenceByXPathUnmarshaller requestedUnmarshaller;
+
+        @Override
+        protected ReferenceByXPathUnmarshaller createUnmarshallingContext(Object root,
+                                                                          HierarchicalStreamReader reader,
+                                                                          ConverterLookup converterLookup,
+                                                                          Mapper mapper) {
+
+            assertNull("strategy can only make one unmarshaller", requestedUnmarshaller);
+            requestedUnmarshaller = (ReferenceByXPathUnmarshaller) super.createUnmarshallingContext(root, reader, converterLookup, mapper);
+            return requestedUnmarshaller;
+        }
+
+        @Override
+        protected ReferenceByXPathMarshaller createMarshallingContext(HierarchicalStreamWriter writer,
+                                                                      ConverterLookup converterLookup,
+                                                                      Mapper mapper) {
+
+            assertNull("strategy can only make one marshaller", requestedMarshaller);
+            requestedMarshaller = (ReferenceByXPathMarshaller) super.createMarshallingContext(writer, converterLookup, mapper);
+            return requestedMarshaller;
+        }
+    }
+
+    @SuppressWarnings("unchecked") //use of document.things : Untyped list, only contains URLs
+    public void testDoNotKeepXPathMapForImmutablesOnMarshall() throws MalformedURLException {
+        //configure XStream
+        CountingXPathStrategy marshallingStrategy = new CountingXPathStrategy();
+        xstream.alias("ThingsDocument", WithNamedList.class);
+        xstream.setMarshallingStrategy(marshallingStrategy);
+
+        //setup document
+        WithNamedList document = new WithNamedList("immutables!");
+        URL sharedURL = new URL("http://jira.codehaus.org/browse");
+        document.things.add(sharedURL);
+        document.things.add(sharedURL);
+
+        //act
+        String serialized = xstream.toXML(document);
+
+        //assert
+        ObjectIdDictionary trackedPathsOnMarshal = getReferences(marshallingStrategy.requestedMarshaller);
+
+        assertTrue(trackedPathsOnMarshal.containsId(document));
+        assertTrue(trackedPathsOnMarshal.containsId(document.things));
+        assertEquals(2, trackedPathsOnMarshal.size());
+    }
+
+    @SuppressWarnings("unchecked") //use of document.things : Untyped list, only contains URLs
+    public void testDoNotKeepXPathMapForImmutablesOnUnmarshall() throws MalformedURLException{
+        //configure XStream
+        CountingXPathStrategy marshallingStrategy = new CountingXPathStrategy();
+        xstream.alias("ThingsDocument", WithNamedList.class);
+        xstream.setMarshallingStrategy(marshallingStrategy);
+
+        //setup document
+        String document = "" +
+                "<ThingsDocument>" +
+                "  <things>" +
+                "    <url>http://jira.codehaus.org/browse</url>" +
+                "    <url>http://jira.codehaus.org/browse</url>" +
+                "  </things>" +
+                "  <name>immutables!</name>" +
+                "</ThingsDocument>";
+
+        //act
+        Object result = xstream.fromXML(document);
+
+        //assert
+        Map trackedPathsOnUnmarshal = getReferences(marshallingStrategy.requestedUnmarshaller);
+
+        assertTrue(trackedPathsOnUnmarshal.containsKey(new Path("/ThingsDocument/things")));
+        assertTrue(trackedPathsOnUnmarshal.containsKey(new Path("/ThingsDocument")));
+        assertEquals(2, trackedPathsOnUnmarshal.size());
+    }
+
+    public static class DomainType extends StandardObject{
+        public String value;
+
+        public DomainType(String value){
+            this.value = value;
+        }
+    }
+
+    @SuppressWarnings("unchecked") //use of document.things : Untyped list, only contains URLs
+    public void testDoesKeepXPathMapForBackwardsCompatibleImmutablesOnUnmarshall() throws MalformedURLException{
+        //configure XStream
+        CountingXPathStrategy marshallingStrategy = new CountingXPathStrategy();
+        xstream.alias("ThingsDocument", WithNamedList.class);
+        xstream.alias("DomainType", DomainType.class);
+        xstream.setMarshallingStrategy(marshallingStrategy);
+        xstream.addImmutableType(DomainType.class);
+
+        //setup document
+        String document = "" +
+                "<ThingsDocument>" +
+                "  <things>" +
+                "    <DomainType>" +
+                "      <value>http://jira.codehaus.org/browse</value>" +
+                "    </DomainType>" +
+                "    <DomainType>" +
+                "      <value>http://jira.codehaus.org/browse</value>" +
+                "    </DomainType>" +
+                "  </things>" +
+                "  <name>immutables!</name>" +
+                "</ThingsDocument>";
+
+        //act
+        Object result = xstream.fromXML(document);
+
+        //assert
+        Map trackedPathsOnUnmarshal = getReferences(marshallingStrategy.requestedUnmarshaller);
+
+        assertTrue(trackedPathsOnUnmarshal.containsKey(new Path("/ThingsDocument/things")));
+        assertTrue(trackedPathsOnUnmarshal.containsKey(new Path("/ThingsDocument")));
+        assertTrue(trackedPathsOnUnmarshal.containsKey(new Path("/ThingsDocument/things/DomainType")));
+        assertTrue(trackedPathsOnUnmarshal.containsKey(new Path("/ThingsDocument/things/DomainType[2]")));
+        assertEquals(4, trackedPathsOnUnmarshal.size());
+    }
+
+    private Map<Path, Object> getReferences(ReferenceByXPathUnmarshaller requestedUnmarshaller) {
+        try {
+            Field field = AbstractReferenceUnmarshaller.class.getDeclaredField("values");
+            field.setAccessible(true);
+            return (Map) field.get(requestedUnmarshaller);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ObjectIdDictionary getReferences(ReferenceByXPathMarshaller requestedMarshaller) {
+        try {
+            Field field = AbstractReferenceMarshaller.class.getDeclaredField("references");
+            field.setAccessible(true);
+            return (ObjectIdDictionary) field.get(requestedMarshaller);
+        }
+        catch(Exception e){
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
continuation of [The PR over at gg-xstream](https://github.com/Groostav/XStream-GG/pull/2)

@joehni My apologies for all the trouble! This is my first contribution to a significant open source project, and my first attempt at cross-project github use.