### PR TITLE
JavaBeanConverter: Always serialize fields with null values, fixes #5.

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/converters/javabean/JavaBeanConverter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/javabean/JavaBeanConverter.java
@@ -18,6 +18,8 @@ import com.thoughtworks.xstream.converters.ConversionException;
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.converters.javabean.BeanProvider;
+import com.thoughtworks.xstream.converters.javabean.JavaBeanProvider;
 import com.thoughtworks.xstream.converters.reflection.MissingFieldException;
 import com.thoughtworks.xstream.core.util.FastField;
 import com.thoughtworks.xstream.io.ExtendedHierarchicalStreamWriterHelper;
@@ -78,6 +80,8 @@ public class JavaBeanConverter implements Converter {
                     final Object newObj) {
                 if (newObj != null) {
                     writeField(propertyName, fieldType, newObj, definedIn);
+                } else {
+                    writeNullField(propertyName);
                 }
             }
 
@@ -92,6 +96,13 @@ public class JavaBeanConverter implements Converter {
                 }
                 context.convertAnother(newObj);
 
+                writer.endNode();
+            }
+
+            private void writeNullField(final String propertyName) {
+                final String serializedMember = mapper.serializedMember(source.getClass(), propertyName);
+                ExtendedHierarchicalStreamWriterHelper.startNode(writer, serializedMember, Mapper.Null.class);
+                writer.addAttribute(classAttributeName, mapper.serializedClass(Mapper.Null.class));
                 writer.endNode();
             }
         });

--- a/xstream/src/test/com/thoughtworks/xstream/converters/javabean/JavaBeanConverterTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/converters/javabean/JavaBeanConverterTest.java
@@ -170,6 +170,19 @@ public class JavaBeanConverterTest extends TestCase {
         }
     }
 
+    public void testRoundtripWithNullValue() {
+        World world = new World();
+        world.setAString(null);
+
+        XStream xstream = new XStream();
+        xstream.registerConverter(new JavaBeanConverter(xstream.getMapper(), new BeanProvider(
+            new StringComparator())), XStream.PRIORITY_LOW);
+        xstream.allowTypes(World.class);
+
+        World world2 = (World) xstream.fromXML(xstream.toXML(world));
+        assertEquals(null, world2.getAString());
+    }
+
     public void testSerializesAllPrimitiveFieldsInACustomObject() {
         World world = new World();
 


### PR DESCRIPTION
As there is no way to quickly and correctly determine the default values of bean properties, this seems to be the best solution for now.