### PR TITLE
Use ConcurrentHashMap in FieldDictionary caching

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/converters/reflection/FieldDictionary.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/reflection/FieldDictionary.java
@@ -49,7 +49,7 @@ public class FieldDictionary implements Caching {
         init();
     }
 
-    protected void init() {
+    private void init() {
         keyedByFieldNameCache = new ConcurrentHashMap<Class<?>, Map<String, Field>>();
         keyedByFieldKeyCache = new ConcurrentHashMap<Class<?>, Map<FieldKey, Field>>();
         keyedByFieldNameCache.put(Object.class, Collections.<String, Field>emptyMap());


### PR DESCRIPTION
Hi,

This pull request is based on a few thread dumps of an application that was under load (~200 applications threads).  I noticed that there was some blocking on the synchronized block in FieldDictionary.  I got to looking at the code and wondered if a concurrent hash map might help.

Wondering what everyone's thoughts on the idea is...happy to follow-up on any suggestions/modifications.

Thanks