### PR TITLE
Improve scalability and performance of FieldDictionary

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/converters/reflection/FieldDictionary.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/reflection/FieldDictionary.java
@@ -13,15 +13,12 @@ package com.thoughtworks.xstream.converters.reflection;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -113,7 +110,7 @@ public class FieldDictionary implements Caching {
 
     }
 
-    private synchronized DictionaryEntry buildCache(final Class<?> type) {
+    private DictionaryEntry buildCache(final Class<?> type) {
         Class<?> cls = type;
         DictionaryEntry lastDictionaryEntry = null;
         final LinkedList<Class<?>> superClasses = new LinkedList<Class<?>>();
@@ -133,7 +130,10 @@ public class FieldDictionary implements Caching {
             DictionaryEntry currentDictionaryEntry = dictionaryEntries.get(cls);
             if (currentDictionaryEntry == null) {
                 currentDictionaryEntry = buildDictionaryEntryForClass(cls, lastDictionaryEntry);
-                dictionaryEntries.put(cls, currentDictionaryEntry);
+                DictionaryEntry existingValue = dictionaryEntries.putIfAbsent(cls, currentDictionaryEntry);
+                if (existingValue != null) {
+                	currentDictionaryEntry = existingValue;
+                }
             }
             lastDictionaryEntry = currentDictionaryEntry;
         }
@@ -179,11 +179,11 @@ public class FieldDictionary implements Caching {
 	}
 
     @Override
-    public synchronized void flushCache() {
-        dictionaryEntries.clear();
+    public void flushCache() {
         if (sorter instanceof Caching) {
             ((Caching)sorter).flushCache();
         }
+        dictionaryEntries.clear();
     }
 
     protected Object readResolve() {

--- a/xstream/src/test/com/thoughtworks/xstream/converters/reflection/FieldDictionaryTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/converters/reflection/FieldDictionaryTest.java
@@ -45,7 +45,7 @@ public class FieldDictionaryTest extends TestCase {
         super.setUp();
         fieldDictionary = new FieldDictionary();
         assertNoDuplicateHashMap = new AssertNoDuplicateHashMap<Class<?>, Map<String, Field>>();
-        Field field = FieldDictionary.class.getDeclaredField("keyedByFieldNameCache");
+        Field field = FieldDictionary.class.getDeclaredField("dictionaryEntries");
         field.setAccessible(true);
         field.set(fieldDictionary, assertNoDuplicateHashMap);
     }


### PR DESCRIPTION
Having multiple threads on a multi core machine, FieldDictionary becomes a bottleneck during serialization / deserialization. Using a ConcurrentHashMap and synchronizing only when no cache entry has been found has already been merged a couple of days ago, but in my opinion further optimizations are possible:

* Use only one HashMap so that lookup is less error prone
* Refactoring for better maintainability
* Don't calculate caches for classes, that have already been cached
* Remove synchronization: allow to calculate different object hierarchies in parallel

I would love to see these improvements in 1.5.0. By the way, do you already have an idea, when 1.5.0 will be released. I'm thinking about porting the change back to 1.4.x, because I need the improvement in a couple of weeks.