### PR TITLE
DefaultConverterLookup does not synchronize iteration on a synchronized map

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/core/DefaultConverterLookup.java
+++ b/xstream/src/java/com/thoughtworks/xstream/core/DefaultConverterLookup.java
@@ -56,10 +56,12 @@ public class DefaultConverterLookup implements ConverterLookup, ConverterRegistr
     @Override
     public void registerConverter(final Converter converter, final int priority) {
         converters.add(converter, priority);
-        for (final Iterator<Class<?>> iter = typeToConverterMap.keySet().iterator(); iter.hasNext();) {
-            final Class<?> type = iter.next();
-            if (converter.canConvert(type)) {
-                iter.remove();
+        synchronized (typeToConverterMap) {
+            for (final Iterator<Class<?>> iter = typeToConverterMap.keySet().iterator(); iter.hasNext();) {
+                final Class<?> type = iter.next();
+                if (converter.canConvert(type)) {
+                    iter.remove();
+                }
             }
         }
     }


### PR DESCRIPTION
In DefaultConverterLookup.java:59, the synchronized map, typeToConverterMap, is iterated over in an unsynchronized manner, but according to the [Oracle Java 7 API specification](http://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#synchronizedMap%28java.util.Map%29),
this is not thread-safe and can lead to non-deterministic behavior. This pull request adds a fix by synchronizing the iteration on typeToConverterMap.