### PR TITLE
Added constructor to ToAttributedValueConverter 

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/converters/extended/ToAttributedValueConverter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/extended/ToAttributedValueConverter.java
@@ -60,6 +60,20 @@ public class ToAttributedValueConverter implements Converter {
 
     /**
      * Creates a new ToAttributedValueConverter instance.
+     *
+     * @param type the type that is handled by this converter instance
+     * @param mapper the mapper in use
+     * @param reflectionProvider the reflection provider in use
+     * @param lookup the converter lookup in use
+     */
+    public ToAttributedValueConverter(
+            final Class<?> type, final Mapper mapper, final ReflectionProvider reflectionProvider,
+            final ConverterLookup lookup) {
+        this(type, mapper, reflectionProvider, lookup, null, null);
+    }
+
+    /**
+     * Creates a new ToAttributedValueConverter instance.
      * 
      * @param type the type that is handled by this converter instance
      * @param mapper the mapper in use

--- a/xstream/src/test/com/thoughtworks/acceptance/annotations/ParametrizedConverterTest.java
+++ b/xstream/src/test/com/thoughtworks/acceptance/annotations/ParametrizedConverterTest.java
@@ -58,6 +58,7 @@ public class ParametrizedConverterTest extends AbstractAcceptanceTest {
         xstream.alias("type", Type.class);
         xstream.processAnnotations(MyMap.class);
         xstream.processAnnotations(DerivedType.class);
+        xstream.processAnnotations(AttributedType.class);
         xstream.processAnnotations(SimpleBean.class);
         xstream.processAnnotations(ContainsMap.class);
         xstream.processAnnotations(ContainsMap2.class);
@@ -163,6 +164,24 @@ public class ParametrizedConverterTest extends AbstractAcceptanceTest {
         public DerivedType(Decimal decimal, Boolean bool, E e) {
             super(decimal, bool);
             this.e = e;
+        }
+    }
+
+    public void testConverterWithoutTypeParameters() {
+        final Type value = new AttributedType(new Decimal("1.5"), new Boolean(true), "test");
+        String expected = "<attrtype decimal='1.5' boolean='true' agreement='yes' string='test'/>".replace('\'', '"');
+        assertBothWays(value, expected);
+    }
+
+    @XStreamAlias("attrtype")
+    @XStreamConverter(value=ToAttributedValueConverter.class)
+    public static class AttributedType extends Type {
+
+        private String string;
+
+        public AttributedType(Decimal decimal, Boolean bool, String string) {
+            super(decimal, bool);
+            this.string = string;
         }
     }
 


### PR DESCRIPTION
As we discussed in #41 I've added constructor to ToAttributedValueConverter  that omits the valueFielName argument. 

Sorry for my bad English... Let me know if there is some mistake with grammar in my code. 