### PR TITLE
Do not write AMP if it is already an AMP

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/io/xml/PrettyPrintWriter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/io/xml/PrettyPrintWriter.java
@@ -219,30 +219,37 @@ public class PrettyPrintWriter extends AbstractXmlWriter {
                 }
                 break;
             case '&':
-				if (Arrays.equals(text.substring(i, i + NULL.length).toCharArray(), NULL)) {
-					writer.write(NULL);
-					i = i + NULL.length - 1;
-				} else if (Arrays.equals(text.substring(i, i + AMP.length).toCharArray(), AMP)) {
-					writer.write(AMP);
-					i = i + AMP.length - 1;
-				} else if (Arrays.equals(text.substring(i, i + LT.length).toCharArray(), LT)) {
-					writer.write(LT);
-					i = i + LT.length - 1;
-				} else if (Arrays.equals(text.substring(i, i + GT.length).toCharArray(), GT)) {
-					writer.write(GT);
-					i = i + GT.length - 1;
-				} else if (Arrays.equals(text.substring(i, i + CR.length).toCharArray(), CR)) {
-					writer.write(CR);
-					i = i + CR.length - 1;
-				} else if (Arrays.equals(text.substring(i, i + QUOT.length).toCharArray(), QUOT)) {
-					writer.write(QUOT);
-					i = i + QUOT.length - 1;
-				} else if (Arrays.equals(text.substring(i, i + APOS.length).toCharArray(), APOS)) {
-					writer.write(APOS);
-					i = i + APOS.length - 1;
-				} else {
-					writer.write(AMP);
-				}
+		if (i + NULL.length <= text.length() && 
+				Arrays.equals(text.substring(i, i + NULL.length).toCharArray(), NULL)) {
+			writer.write(NULL);
+			i = i + NULL.length - 1;
+		} else if (i + AMP.length <= text.length() &&
+					Arrays.equals(text.substring(i, i + AMP.length).toCharArray(), AMP)) {
+			writer.write(AMP);
+			i = i + AMP.length - 1;
+		} else if (i + LT.length <= text.length() &&
+				Arrays.equals(text.substring(i, i + LT.length).toCharArray(), LT)) {
+			writer.write(LT);
+			i = i + LT.length - 1;
+		} else if (i + GT.length <= text.length() &&
+				Arrays.equals(text.substring(i, i + GT.length).toCharArray(), GT)) {
+			writer.write(GT);
+			i = i + GT.length - 1;
+		} else if (i + CR.length <= text.length() &&
+				Arrays.equals(text.substring(i, i + CR.length).toCharArray(), CR)) {
+			writer.write(CR);
+			i = i + CR.length - 1;
+		} else if (i + QUOT.length <= text.length() &&
+				Arrays.equals(text.substring(i, i + QUOT.length).toCharArray(), QUOT)) {
+			writer.write(QUOT);
+			i = i + QUOT.length - 1;
+		} else if (i + APOS.length <= text.length() &&
+				Arrays.equals(text.substring(i, i + APOS.length).toCharArray(), APOS)) {
+			writer.write(APOS);
+			i = i + APOS.length - 1;
+		} else {
+			writer.write(AMP);
+		}
                 break;
             case '<':
                 writer.write(LT);

--- a/xstream/src/java/com/thoughtworks/xstream/io/xml/PrettyPrintWriter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/io/xml/PrettyPrintWriter.java
@@ -218,7 +218,30 @@ public class PrettyPrintWriter extends AbstractXmlWriter {
                 }
                 break;
             case '&':
-                writer.write(AMP);
+				if (Arrays.equals(text.substring(i, i + NULL.length).toCharArray(), NULL)) {
+					writer.write(NULL);
+					i = i + NULL.length - 1;
+				} else if (Arrays.equals(text.substring(i, i + AMP.length).toCharArray(), AMP)) {
+					writer.write(AMP);
+					i = i + AMP.length - 1;
+				} else if (Arrays.equals(text.substring(i, i + LT.length).toCharArray(), LT)) {
+					writer.write(LT);
+					i = i + LT.length - 1;
+				} else if (Arrays.equals(text.substring(i, i + GT.length).toCharArray(), GT)) {
+					writer.write(GT);
+					i = i + GT.length - 1;
+				} else if (Arrays.equals(text.substring(i, i + CR.length).toCharArray(), CR)) {
+					writer.write(CR);
+					i = i + CR.length - 1;
+				} else if (Arrays.equals(text.substring(i, i + QUOT.length).toCharArray(), QUOT)) {
+					writer.write(QUOT);
+					i = i + QUOT.length - 1;
+				} else if (Arrays.equals(text.substring(i, i + APOS.length).toCharArray(), APOS)) {
+					writer.write(APOS);
+					i = i + APOS.length - 1;
+				} else {
+					writer.write(AMP);
+				}
                 break;
             case '<':
                 writer.write(LT);

--- a/xstream/src/java/com/thoughtworks/xstream/io/xml/PrettyPrintWriter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/io/xml/PrettyPrintWriter.java
@@ -12,6 +12,7 @@
 package com.thoughtworks.xstream.io.xml;
 
 import java.io.Writer;
+import java.util.Arrays;
 
 import com.thoughtworks.xstream.core.util.FastStack;
 import com.thoughtworks.xstream.core.util.QuickWriter;


### PR DESCRIPTION
Example:
"News \&amp; Sports" read by [fromXML](http://x-stream.github.io/javadoc/com/thoughtworks/xstream/XStream.html#fromXML-java.io.File-) and rewritten with [toXML](http://x-stream.github.io/javadoc/com/thoughtworks/xstream/XStream.html#toXML-java.lang.Object-) would produce "News \&amp;amp; Sports" (escaped with backslash to show the issue)

Is this behaviour desired? I thought it might be a bug, so here is a possible fix to it.
