### PR TITLE
Initialize size of string buffer in Base64Encoder

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/core/util/Base64Encoder.java
+++ b/xstream/src/java/com/thoughtworks/xstream/core/util/Base64Encoder.java
@@ -56,7 +56,8 @@ public class Base64Encoder {
     }
 
     public String encode(byte[] input) {
-        StringBuffer result = new StringBuffer();
+        int stringSize = computeResultingStringSize(input);
+        StringBuffer result = new StringBuffer(stringSize);
         int outputCharCount = 0;
         for (int i = 0; i < input.length; i += 3) {
             int remaining = Math.min(3, input.length - i);
@@ -64,7 +65,16 @@ public class Base64Encoder {
             for (int j = 0; j < 4; j++) result.append(remaining + 1 > j ? SIXTY_FOUR_CHARS[0x3f & oneBigNumber >> 6 * (3 - j)] : '=');
             if ((outputCharCount += 4) % 76 == 0) result.append('\n');
         }
-        return result.toString();
+        String s = result.toString();
+        return s;
+    }
+
+    //package private for testing purpose
+    int computeResultingStringSize(byte[] input) {
+        int stringSize = (input.length / 3) + (input.length % 3 == 0 ? 0 : 1);
+        stringSize *= 4;
+        stringSize += (stringSize / 76);
+        return stringSize;
     }
 
     public byte[] decode(String input) {

--- a/xstream/src/test/com/thoughtworks/xstream/core/util/Base64EncoderTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/core/util/Base64EncoderTest.java
@@ -90,4 +90,25 @@ public class Base64EncoderTest extends AbstractAcceptanceTest {
         assertByteArrayEquals(input, encoder.decode(expected));
     }
 
+    public void testInitializeStringBufferWithExpectedSizeUsing6BytesInput() throws Exception {
+        byte input[] = {1, 2, 3, 4, 5, 6};
+        assertEquals(encoder.encode(input).length(), encoder.computeResultingStringSize(input));
+    }
+
+    public void testInitializeStringBufferWithExpectedSizeUsing1BytesInput() throws Exception {
+        byte input[] = {1};
+        assertEquals(encoder.encode(input).length(), encoder.computeResultingStringSize(input));
+    }
+
+    public void testInitializeStringBufferWithExpectedSizeUsing4BytesInput() throws Exception {
+        byte input[] = {1, 2, 3, 4};
+        assertEquals(encoder.encode(input).length(), encoder.computeResultingStringSize(input));
+    }
+    
+    public void testInitializeStringBufferWithExpectedSizeUsing140BytesInput() throws Exception {
+        byte input[] = new byte[140];
+        for (int i = 0; i < 139; i++) input[i] = (byte) (i + 1);
+        assertEquals(encoder.encode(input).length(), encoder.computeResultingStringSize(input));
+    }
+
 }


### PR DESCRIPTION
In order to avoid the string builder to expand and copy the underlying
char array it uses, it is best to initialize it using an initial size.
This add the initialization of the StrungBuffer with a size calculated
from the input byte array.