### PR TITLE
try to fix duplicated fields in attribute and child element

### DIFF
--- a/xstream/src/test/com/thoughtworks/xstream/mapper/newtest1/Delete.java
+++ b/xstream/src/test/com/thoughtworks/xstream/mapper/newtest1/Delete.java
@@ -1,0 +1,25 @@
+package com.thoughtworks.xstream.mapper.newtest1;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+@XStreamAlias("delete")
+public class Delete {
+	@XStreamAlias("id")
+	@XStreamAsAttribute
+	public String id;
+
+	@XStreamAlias("parameterType")
+	@XStreamAsAttribute
+	public String parameterType;
+
+	
+	public String getParameterType() {
+		return parameterType;
+	}
+
+	public void setParameterType(String parameterType) {
+		this.parameterType = parameterType;
+	}
+	
+}

--- a/xstream/src/test/com/thoughtworks/xstream/mapper/newtest1/Id.java
+++ b/xstream/src/test/com/thoughtworks/xstream/mapper/newtest1/Id.java
@@ -1,0 +1,30 @@
+package com.thoughtworks.xstream.mapper.newtest1;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+@XStreamAlias("id")
+public class Id {
+	@XStreamAlias("column")
+	@XStreamAsAttribute
+	public String column;
+	
+	@XStreamAlias("property")
+	@XStreamAsAttribute	
+	public String property;
+	
+	
+	public String getColumn() {
+		return column;
+	}
+	public void setColumn(String column) {
+		this.column = column;
+	}
+	public String getProperty() {
+		return property;
+	}
+	public void setProperty(String property) {
+		this.property = property;
+	}
+	
+}

--- a/xstream/src/test/com/thoughtworks/xstream/mapper/newtest1/Insert.java
+++ b/xstream/src/test/com/thoughtworks/xstream/mapper/newtest1/Insert.java
@@ -1,0 +1,25 @@
+package com.thoughtworks.xstream.mapper.newtest1;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+@XStreamAlias("insert")
+public class Insert {
+	@XStreamAlias("id")
+	@XStreamAsAttribute
+	public String id;
+
+	@XStreamAlias("parameterType")
+	@XStreamAsAttribute
+	public String parameterType;
+
+	
+	public String getParameterType() {
+		return parameterType;
+	}
+
+	public void setParameterType(String parameterType) {
+		this.parameterType = parameterType;
+	}
+	
+}

--- a/xstream/src/test/com/thoughtworks/xstream/mapper/newtest1/Mapper.java
+++ b/xstream/src/test/com/thoughtworks/xstream/mapper/newtest1/Mapper.java
@@ -1,0 +1,82 @@
+package com.thoughtworks.xstream.mapper.newtest1;
+
+import java.util.List;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+@XStreamAlias("mapper")
+public class Mapper {
+	
+	@XStreamImplicit(itemFieldName="resultMap")
+	public List<ResultMap> resultMaps;
+
+	@XStreamImplicit(itemFieldName="select")
+	public List<Select> select;
+	
+	@XStreamImplicit(itemFieldName="insert")
+	public List<Insert> insert;
+
+	@XStreamImplicit(itemFieldName="update")
+	public List<Update> update;
+
+	@XStreamImplicit(itemFieldName="delete")
+	public List<Delete> delete;
+
+	public Mapper() {
+		System.out.println("Mapper ctor here");
+	}
+	
+	public ResultMap getResultMap(String id) {
+		for(ResultMap rm: resultMaps) {
+			if(rm.id.equals(id)) {
+				return rm;
+			}
+		}
+		return null;
+	}
+	
+	public String toString() {
+		String ret = "";
+		if(this.resultMaps!=null) {
+			for(ResultMap rm:this.resultMaps) {
+				ret = ret + rm.toString();
+			}
+		}
+		return ret;
+	}
+	
+	public List<Select> getSelect() {
+		return select;
+	}
+
+	public void setSelect(List<Select> select) {
+		this.select = select;
+	}
+
+	public List<Insert> getInsert() {
+		return insert;
+	}
+
+	public void setInsert(List<Insert> insert) {
+		this.insert = insert;
+	}
+
+	public List<Update> getUpdate() {
+		return update;
+	}
+
+	public void setUpdate(List<Update> update) {
+		this.update = update;
+	}
+
+	public List<Delete> getDelete() {
+		return delete;
+	}
+
+	public void setDelete(List<Delete> delete) {
+		this.delete = delete;
+	}
+
+	
+}

--- a/xstream/src/test/com/thoughtworks/xstream/mapper/newtest1/Result.java
+++ b/xstream/src/test/com/thoughtworks/xstream/mapper/newtest1/Result.java
@@ -1,0 +1,35 @@
+package com.thoughtworks.xstream.mapper.newtest1;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+@XStreamAlias("result")
+public class Result {
+	
+	@XStreamAlias("column")
+	@XStreamAsAttribute
+	public String column;
+	
+	@XStreamAlias("property")
+	@XStreamAsAttribute	
+	public String property;
+	
+	
+	public String getColumn() {
+		return column;
+	}
+	public void setColumn(String column) {
+		this.column = column;
+	}
+	public String getProperty() {
+		return property;
+	}
+	public void setProperty(String property) {
+		this.property = property;
+	}
+	
+	public String toString() {
+		return this.column  + " " + this.property;
+	}
+	
+}

--- a/xstream/src/test/com/thoughtworks/xstream/mapper/newtest1/ResultMap.java
+++ b/xstream/src/test/com/thoughtworks/xstream/mapper/newtest1/ResultMap.java
@@ -1,0 +1,77 @@
+package com.thoughtworks.xstream.mapper.newtest1;
+
+import java.util.List;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+@XStreamAlias("resultMap")
+public class ResultMap {
+	
+	@XStreamAlias("id")
+	@XStreamAsAttribute
+	public String id;
+
+	@XStreamAlias("type")
+	@XStreamAsAttribute
+	public String type;
+	
+	
+	@XStreamAlias("id")
+	Id id1;
+	
+	
+	@XStreamImplicit(itemFieldName="result")
+	List<Result> results;
+	
+
+	public ResultMap() {
+		System.out.println("resultMap ctor here");
+	}
+	
+	public String toString() {
+		String ret = id + " " + type + " \n";
+		if(results!=null) {
+			for(int i=0;i<results.size();i++) {
+				ret = ret + results.get(i).toString();
+			}
+		}
+		return ret;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public Id getId1() {
+		return id1;
+	}
+
+	public void setId1(Id id1) {
+		this.id1 = id1;
+	}
+
+	public List<Result> getResults() {
+		return results;
+	}
+
+	public void setResults(List<Result> results) {
+		this.results = results;
+	}
+
+	
+	
+}

--- a/xstream/src/test/com/thoughtworks/xstream/mapper/newtest1/Select.java
+++ b/xstream/src/test/com/thoughtworks/xstream/mapper/newtest1/Select.java
@@ -1,0 +1,61 @@
+package com.thoughtworks.xstream.mapper.newtest1;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+@XStreamAlias("select")
+public class Select {
+	
+	@XStreamAlias("id")
+	@XStreamAsAttribute
+	public String id;
+
+	
+	@XStreamAlias("parameterType")
+	@XStreamAsAttribute
+	public String parameterType;
+
+	@XStreamAlias("resultType")
+	@XStreamAsAttribute
+	public String resultType;
+
+	@XStreamAlias("resultMap")
+	@XStreamAsAttribute
+	public String resultMap;
+	
+	
+
+	public String getParameterType() {
+		return parameterType;
+	}
+
+	public void setParameterType(String parameterType) {
+		this.parameterType = parameterType;
+	}
+
+	public String getResultType() {
+		return resultType;
+	}
+
+	public void setResultType(String resultType) {
+		this.resultType = resultType;
+	}
+
+	public String getResultMap() {
+		return resultMap;
+	}
+
+	public void setResultMap(String resultMap) {
+		this.resultMap = resultMap;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+	
+	
+}

--- a/xstream/src/test/com/thoughtworks/xstream/mapper/newtest1/TestMapper.java
+++ b/xstream/src/test/com/thoughtworks/xstream/mapper/newtest1/TestMapper.java
@@ -1,0 +1,27 @@
+package com.thoughtworks.xstream.mapper.newtest1;
+
+import java.io.InputStream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.security.AnyTypePermission;
+
+
+/**
+ * test verify duplicated field
+ */
+public class TestMapper {
+	
+    public static void main(String[] args) throws Exception {
+        XStream xs = new XStream();
+    	
+        xs.addPermission(AnyTypePermission.ANY);
+        xs.ignoreUnknownElements();
+        xs.processAnnotations(Mapper.class);
+         
+        InputStream is = TestMapper.class.getResourceAsStream("mapper1.xml");
+        Mapper o = (Mapper)xs.fromXML(is);
+        for(ResultMap rm:o.resultMaps) {
+        	System.out.println(rm);
+        }
+    }
+}

--- a/xstream/src/test/com/thoughtworks/xstream/mapper/newtest1/Update.java
+++ b/xstream/src/test/com/thoughtworks/xstream/mapper/newtest1/Update.java
@@ -1,0 +1,32 @@
+package com.thoughtworks.xstream.mapper.newtest1;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+@XStreamAlias("update")
+public class Update {
+	@XStreamAlias("id")
+	@XStreamAsAttribute
+	public String id;
+	
+	@XStreamAlias("parameterType")
+	@XStreamAsAttribute
+	public String parameterType;
+
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getParameterType() {
+		return parameterType;
+	}
+
+	public void setParameterType(String parameterType) {
+		this.parameterType = parameterType;
+	}
+}

--- a/xstream/src/test/com/thoughtworks/xstream/mapper/newtest1/mapper1.xml
+++ b/xstream/src/test/com/thoughtworks/xstream/mapper/newtest1/mapper1.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.test.dao.mapper1" >
+
+<!-- Result Map 数据库映射到实体类  , single table result -->
+<resultMap id="mapArticle" type="com.test.dao.Mapper1" >
+	<id     column="no"       property="articleNo"/>
+	<result column="title"       property="title"/>
+</resultMap> 
+
+<select id="getPrimaryKey" resultType="java.lang.Long">
+	select S_ARTICLE.nextval from dual
+</select>
+
+
+<insert id="insert1" >
+	select S_ARTICLE.nextval from dual
+</insert>
+
+<update id="updateArticleBody" parameterType="com.test.db.entity.Article" >
+	update bus_article article
+	<set>
+		update_time = #{article.updateTime, jdbcType=VARCHAR}
+		body =#{article.body, jdbcType=VARCHAR} 
+	</set> 
+	where article_no=#{article.articleNo}
+	<include refid="filterByOperatorForWrite"></include>
+</update>
+
+<delete id="deleteArticle" parameterType="com.test.db.entity.Article">
+    delete from BUS_ARTICLE article where article_no=#{article.articleNo} 
+    <include refid="filterByOperatorForWrite"/>
+</delete>
+
+
+</mapper>


### PR DESCRIPTION
Hi, this pull request to try to fix duplicated name in attribute and child element like following xml:

<mapper namespace="com.test.dao.mapper1" >
<resultMap id="mapArticle" type="com.test.dao.Mapper1" >
	<id     column="no"       property="articleNo"/>
	<result column="title"       property="title"/>
</resultMap> 
....
</mapper>

resultMapper has both attribute and child element named with "id".
this is mybatis(http://www.mybatis.org) mapper xml.

I know that the fix will fail some other testcases, because this is only fix using in annotation.
just not sure if the fix is right way to go.
Thanks!
