### PR TITLE
AnyAnnotationTypePermission that accepts any class with XStream annotation

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/security/AnyAnnotationTypePermission.java
+++ b/xstream/src/java/com/thoughtworks/xstream/security/AnyAnnotationTypePermission.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2017 XStream Committers.
+ * All rights reserved.
+ */
+package com.thoughtworks.xstream.security;
+
+import java.util.regex.Pattern;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAliasType;
+import com.thoughtworks.xstream.annotations.XStreamInclude;
+
+/**
+ * Permission for any type which is annotated with an XStream annotation.
+ * This presumes that because the class has an XStream annotation, it was designed with XStream in mind,
+ * and therefore it is not vulnerable. Jackson and JAXB follow this philosophy too.
+ * 
+ * @author Geoffrey De Smet
+ * @since 1.5.0
+ */
+public class AnyAnnotationTypePermission implements TypePermission {
+
+    @Override
+    public boolean allows(final Class<?> type) {
+        if (type == null) {
+            return false;
+        }
+        return type.isAnnotationPresent(XStreamAlias.class)
+                || type.isAnnotationPresent(XStreamAliasType.class)
+                || type.isAnnotationPresent(XStreamInclude.class);
+    }
+
+}

--- a/xstream/src/test/com/thoughtworks/xstream/mapper/SecurityMapperTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/mapper/SecurityMapperTest.java
@@ -227,18 +227,19 @@ public class SecurityMapperTest extends TestCase {
         assertAcceptedClass(OtherAliasedFoo.class);
         assertForbiddenClass(OtherAliasedFoo.NestedNonAnnotatedFoo.class);
         assertForbiddenClass(anonymous);
+        assertForbiddenClass(null);
     }
 
     private void assertAcceptedClass(Class<?> type) {
-        assertSame(type, mapper.realClass(type.getName()));
+        assertSame(type, mapper.realClass((type == null) ? null : type.getName()));
     }
 
     private void assertForbiddenClass(Class<?> type) {
         try {
-            mapper.realClass(type.getName());
+            mapper.realClass((type == null) ? null : type.getName());
             fail("Thrown " + ForbiddenClassException.class.getName() + " expected");
         } catch (final ForbiddenClassException e) {
-            assertEquals(type.getName(), e.getMessage());
+            assertEquals((type == null) ? "null" : type.getName(), e.getMessage());
         }
     }
 


### PR DESCRIPTION
**This permission accepts any class with an XStream annotations, because that class was designed with XStream in mind** and therefore it is fair to presume it is not vulnerable.
_Jackson and JAXB follow this philosophy too and they don't have any CVE's against this behavior._

This PR just creates and tests that class, but I strongly believe it should also be added into XStream.setupDefaultSecurity(), so XStream 1.5 isn't harder to use than JAXB and Jackson. However, that's a different issue/discussion, so I haven't included that change here, due to the debatable nature of that change.
(The fact that XStream can also be used without annotations is unrelated to this change, because just because the security framework has to be a pain for xstream usage without annotations, it shouldn't force xstream usage with annotations be as painful if that approach does have a less painful solution.)