### PR TITLE
[JENKINS-49054] TreeUnmarshaller.convert could leave behind a corrupted type stack

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/core/TreeUnmarshaller.java
+++ b/xstream/src/java/com/thoughtworks/xstream/core/TreeUnmarshaller.java
@@ -68,11 +68,9 @@ public class TreeUnmarshaller implements UnmarshallingContext {
     }
 
     protected Object convert(final Object parent, final Class<?> type, final Converter converter) {
+        types.push(type);
         try {
-            types.push(type);
-            final Object result = converter.unmarshal(reader, this);
-            types.popSilently();
-            return result;
+            return converter.unmarshal(reader, this);
         } catch (final ConversionException conversionException) {
             addInformationTo(conversionException, type, converter, parent);
             throw conversionException;
@@ -80,6 +78,8 @@ public class TreeUnmarshaller implements UnmarshallingContext {
             final ConversionException conversionException = new ConversionException(e);
             addInformationTo(conversionException, type, converter, parent);
             throw conversionException;
+        } finally {
+            types.popSilently();
         }
     }
 


### PR DESCRIPTION
https://github.com/jenkinsci/xstream-fork/pull/2 just applied to the upstream trunk with trivial stylistic cleanup.

https://github.com/jenkinsci/jenkins/pull/3248 is an integration test for this in Jenkins but if you need a unit test here let me know and I will try to come up with one.

Also see #70, which proposes backporting of various other fixes (not this one).

@reviewbybees