### PR TITLE
Java 9 setAccessible fix

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/converters/reflection/AbstractAttributedCharacterIteratorAttributeConverter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/reflection/AbstractAttributedCharacterIteratorAttributeConverter.java
@@ -41,7 +41,7 @@ public class AbstractAttributedCharacterIteratorAttributeConverter<T extends Att
         Method method = null;
         try {
             method = AttributedCharacterIterator.Attribute.class.getDeclaredMethod("getName", (Class[])null);
-            if (!method.isAccessible()) {
+            if (!method.isAccessible() && !method.getDeclaringClass().getName().startsWith("java.")) {
                 method.setAccessible(true);
             }
         } catch (final SecurityException e) {

--- a/xstream/src/java/com/thoughtworks/xstream/core/util/Fields.java
+++ b/xstream/src/java/com/thoughtworks/xstream/core/util/Fields.java
@@ -36,7 +36,7 @@ public class Fields {
                     }
                 }
             }
-            if (field != null && !field.isAccessible()) {
+            if (field != null && !field.isAccessible() && !field.getDeclaringClass().getName().startsWith("java.")) {
                 field.setAccessible(true);
             }
         } catch (final SecurityException e) {
@@ -50,7 +50,7 @@ public class Fields {
     public static Field find(final Class<?> type, final String name) {
         try {
             final Field result = type.getDeclaredField(name);
-            if (!result.isAccessible()) {
+            if (!result.isAccessible() && !result.getDeclaringClass().getName().startsWith("java.")) {
                 result.setAccessible(true);
             }
             return result;


### PR DESCRIPTION
I removed some of the offending Java 9 setAccess calls in "java." packages, that caused the following error on the console:

WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.thoughtworks.xstream.core.util.Fields (file:/C:/Java/repository/com/thoughtworks/xstream/xstream/1.4.10/xstream-1.4.10.jar) to field java.util.TreeMap.comparator
WARNING: Please consider reporting this to the maintainers of com.thoughtworks.xstream.core.util.Fields
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

Please check and integrate.

Thanks
Dieter