### PR TITLE
StackTraceElementConverter could crash with some fileName values

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/converters/extended/StackTraceElementConverter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/extended/StackTraceElementConverter.java
@@ -33,7 +33,7 @@ public class StackTraceElementConverter extends AbstractSingleValueConverter {
     // |-------1------| |--2--| |----3-----| |4|
     // (Note group 4 is optional is optional and only present if a colon char exists.)
 
-    private static final Pattern PATTERN = Pattern.compile("^(.+)\\.([^\\(]+)\\(([^:]*)(:(\\d+))?\\)$");
+    private static final Pattern PATTERN = Pattern.compile("^(.+)\\.([^\\(]+)\\((.*?)(:(\\d+))?\\)$");
     private static final StackTraceElementFactory FACTORY = new StackTraceElementFactory();
 
     static class StackTraceElementFactory {

--- a/xstream/src/test/com/thoughtworks/acceptance/AbstractAcceptanceTest.java
+++ b/xstream/src/test/com/thoughtworks/acceptance/AbstractAcceptanceTest.java
@@ -143,8 +143,7 @@ public abstract class AbstractAcceptanceTest extends TestCase {
             } else {
                 // assertEquals(expected.getClass(), actual.getClass());
                 if (!expected.equals(actual)) {
-                    assertEquals("Object deserialization failed", "DESERIALIZED OBJECT\n" + xstream.toXML(expected),
-                        "DESERIALIZED OBJECT\n" + xstream.toXML(actual));
+                    assertEquals(xstream.toXML(expected) + " vs. " + xstream.toXML(actual), expected, actual);
                 }
             }
         }

--- a/xstream/src/test/com/thoughtworks/acceptance/AbstractAcceptanceTest.java
+++ b/xstream/src/test/com/thoughtworks/acceptance/AbstractAcceptanceTest.java
@@ -28,6 +28,7 @@ import com.thoughtworks.xstream.core.util.DefaultDriver;
 import com.thoughtworks.xstream.io.HierarchicalStreamDriver;
 import com.thoughtworks.xstream.io.binary.BinaryStreamReader;
 import com.thoughtworks.xstream.io.binary.BinaryStreamWriter;
+import junit.framework.Assert;
 
 import junit.framework.AssertionFailedError;
 import junit.framework.TestCase;
@@ -131,7 +132,13 @@ public abstract class AbstractAcceptanceTest extends TestCase {
     }
 
     /**
-     * More descriptive version of assertEquals
+     * XStream-specific variant of {@link Assert#assertEquals(Object, Object)}.
+     * While a positive {@link Object#equals} suffices for the comparison to pass,
+     * it also suffices for the XStream serialized form to be identical.
+     * This is commonly necessary when running {@link #assertBothWays(Object, String)}
+     * on a type which does not happen to override {@link Object#equals}.
+     * More subtly, it also reduces the strength of test coverage for lossy converters:
+     * those which can round-trip to an object that actually has different state than the original.
      */
     protected void assertObjectsEqual(final Object expected, final Object actual) {
         if (expected == null) {
@@ -141,9 +148,9 @@ public abstract class AbstractAcceptanceTest extends TestCase {
             if (actual.getClass().isArray()) {
                 assertArrayEquals(expected, actual);
             } else {
-                // assertEquals(expected.getClass(), actual.getClass());
                 if (!expected.equals(actual)) {
-                    assertEquals(xstream.toXML(expected) + " vs. " + xstream.toXML(actual), expected, actual);
+                    assertEquals("Object deserialization failed", "DESERIALIZED OBJECT\n" + xstream.toXML(expected),
+                        "DESERIALIZED OBJECT\n" + xstream.toXML(actual));
                 }
             }
         }

--- a/xstream/src/test/com/thoughtworks/xstream/converters/extended/StackTraceElementConverterTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/converters/extended/StackTraceElementConverterTest.java
@@ -41,6 +41,12 @@ public class StackTraceElementConverterTest extends AbstractAcceptanceTest {
         assertBothWays(trace, expectedXml);
     }
 
+    public void testIncludesDebugInformationWithUnusualFilenames() {
+        final StackTraceElement trace = factory.element("com.blah.SomeClass", "someMethod", "jar:file:/tmp/x-1.0.jar!/com/blah/SomeClass.groovy", 22);
+        final String expectedXml = "<trace>com.blah.SomeClass.someMethod(jar:file:/tmp/x-1.0.jar!/com/blah/SomeClass.groovy:22)</trace>";
+        assertBothWays(trace, expectedXml);
+    }
+
     public void testIncludesNativeMethods() {
         final StackTraceElement trace = factory.nativeMethodElement("com.blah.SomeClass", "someMethod");
         final String expectedXml = "<trace>com.blah.SomeClass.someMethod(Native Method)</trace>";


### PR DESCRIPTION
`StackTraceElement` Javadoc mentions no restrictions on `fileName` format. In [JENKINS-57085](https://issues.jenkins-ci.org/browse/JENKINS-57085) @dwnusbaum discovered that some unusual Groovy scenarios could wind up using a full URL rather than a basename (probably a bug elsewhere).

Note that without 5c925b1, the test will incorrectly pass for

```diff
-    private static final Pattern PATTERN = Pattern.compile("^(.+)\\.([^\\(]+)\\(([^:]*)(:(\\d+))?\\)$");
+    private static final Pattern PATTERN = Pattern.compile("^(.+)\\.([^\\(]+)\\((.*)(:(\\d+))?\\)$");
```

(`*` rather than noneager `*?`) since the converter will never parse out a `lineNumber` yet `assertObjectsEqual` would ignore the `Object.equals` failure and just pay attention to the fact that the XML form is identical either way. (I.e., the XStream form is lossy.)