### PR TITLE
Use .isEmpty()  instead of .size() == 0 where possible.

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/core/util/WeakCache.java
+++ b/xstream/src/java/com/thoughtworks/xstream/core/util/WeakCache.java
@@ -92,7 +92,7 @@ public class WeakCache<K, V> extends AbstractMap<K, V> {
 
     @Override
     public int size() {
-        if (map.size() == 0) {
+        if (map.isEmpty()) {
             return 0;
         }
         final int i[] = new int[1];
@@ -112,7 +112,7 @@ public class WeakCache<K, V> extends AbstractMap<K, V> {
     @Override
     public Collection<V> values() {
         final Collection<V> collection = new ArrayList<>();
-        if (map.size() != 0) {
+        if (!map.isEmpty()) {
             iterate(new Visitor() {
 
                 @Override
@@ -131,7 +131,7 @@ public class WeakCache<K, V> extends AbstractMap<K, V> {
     @Override
     public Set<Map.Entry<K, V>> entrySet() {
         final Set<Map.Entry<K, V>> set = new HashSet<>();
-        if (map.size() != 0) {
+        if (!map.isEmpty()) {
             iterate(new Visitor() {
 
                 @Override

--- a/xstream/src/test/com/thoughtworks/xstream/testutil/DynamicSecurityManager.java
+++ b/xstream/src/test/com/thoughtworks/xstream/testutil/DynamicSecurityManager.java
@@ -56,7 +56,7 @@ public class DynamicSecurityManager extends SecurityManager {
     }
 
     private void updateACC() {
-        if (permissions.size() == 0) {
+        if (permissions.isEmpty()) {
             acc = null;
         } else {
             final ProtectionDomain[] domains = new ProtectionDomain[permissions.size()];


### PR DESCRIPTION
Change-Id: Ie1753f8a51dd32a0019845cce4de104a33c02f48
Signed-off-by: Carsten Hammer <carsten.hammer@t-online.de>