### PR TITLE
making resolution optional for a couple more packages

### DIFF
--- a/xstream/pom.xml
+++ b/xstream/pom.xml
@@ -588,7 +588,7 @@
 
   <properties>
     <bundle.export.package>!com.thoughtworks.xstream.core.util,com.thoughtworks.xstream.*;-noimport:=true</bundle.export.package>
-    <bundle.import.package>org.xmlpull.mxp1;resolution:=optional,org.xmlpull.v1;resolution:=optional,*</bundle.import.package>
+    <bundle.import.package>org.xmlpull.mxp1;resolution:=optional,org.xmlpull.v1;resolution:=optional,com.ibm.xml.xlxp.api.stax;resolution:=optional,com.sun.xml.internal.stream;resolution:=optional,javax.xml.bind;version="[2.3,3)";resolution:=optional,*</bundle.import.package>
   </properties>
 
 </project>


### PR DESCRIPTION
I ran into some problems using xstream 1.4.11.1 in an OSGi container (running inside of an OpenJDK 8 JVM). I didn't do extensive research, but it seems that some of the packages are very unlikely to be available. I think that your OSGi plugin may have detected a couple of Class.forName calls and figured that the packages needed to be available. 

Anyhow, I don't know how quickly you guys run releases, but we'd like to upgrade to 1.4.11 or later, but this issue blocked us. Thanks!