### PR TITLE
a quick, simple IT using PAX to validate OSGi config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,7 @@
     <module>xstream</module>
     <module>xstream-hibernate</module>
     <module>xstream-benchmark</module>
+    <module>xstream-its</module>
   </modules>
 
   <licenses>
@@ -617,6 +618,70 @@
         <scope>test</scope>
       </dependency>
 
+      <!-- Pax Exam Dependencies -->
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-junit4</artifactId>
+        <version>${version.pax.exam}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-invoker-junit</artifactId>
+        <version>${version.pax.exam}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-container-native</artifactId>
+        <version>${version.pax.exam}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-inject</artifactId>
+        <version>${version.pax.exam}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-extender-service</artifactId>
+        <version>${version.pax.exam}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <!-- Preferred link because it does not require an mvn url handler implicitely. -->
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-link-mvn</artifactId>
+        <version>${version.pax.exam}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.geronimo.specs</groupId>
+        <artifactId>geronimo-atinject_1.0_spec</artifactId>
+        <version>1.0</version>
+        <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-link-assembly</artifactId>
+        <version>${version.pax.exam}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>org.apache.felix.framework</artifactId>
+        <version>${version.felix}</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -978,6 +1043,7 @@
     <version.commons.io>1.4</version.commons.io>
     <version.commons.lang>2.4</version.commons.lang>
     <version.dom4j>1.6.1</version.dom4j>
+    <version.felix>4.4.1</version.felix>
     <version.hsqldb>2.2.8</version.hsqldb>
     <version.javaassist>3.12.1.GA</version.javaassist>
     <version.javax.activation>1.1.1</version.javax.activation>
@@ -996,6 +1062,7 @@
     <version.org.json>20080701</version.org.json>
     <version.org.openjdk.jmh>1.21</version.org.openjdk.jmh>
     <version.org.slf4j>1.6.1</version.org.slf4j>
+    <version.pax.exam>4.4.0</version.pax.exam>
     <version.stax>1.2.0</version.stax>
     <version.stax.api>1.0.1</version.stax.api>
     <version.xerces.impl>2.8.1</version.xerces.impl>

--- a/pom.xml
+++ b/pom.xml
@@ -952,6 +952,10 @@
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>${version.plugin.jacoco}</version>
         </plugin>
+        <plugin>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>2.22.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>

--- a/xstream-its/pom.xml
+++ b/xstream-its/pom.xml
@@ -63,7 +63,6 @@
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam-link-mvn</artifactId>
-      <version>${version.pax.exam}</version>
       <scope>test</scope>
     </dependency>
 

--- a/xstream-its/pom.xml
+++ b/xstream-its/pom.xml
@@ -118,8 +118,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
     </plugins>

--- a/xstream-its/pom.xml
+++ b/xstream-its/pom.xml
@@ -134,7 +134,6 @@
         <plugins>
           <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.0</version>
             <executions>
               <execution>
                 <goals>

--- a/xstream-its/pom.xml
+++ b/xstream-its/pom.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>xstream-parent</artifactId>
+    <groupId>com.thoughtworks.xstream</groupId>
+    <version>1.4.12-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>xstream-its</artifactId>
+  <name>XStream ITs</name>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.11</version>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-invoker-junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-container-native</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-inject</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-extender-service</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Preferred link because it does not require an mvn url handler implicitely. -->
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-link-mvn</artifactId>
+      <version>${version.pax.exam}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.geronimo.specs</groupId>
+      <artifactId>geronimo-atinject_1.0_spec</artifactId>
+      <version>1.0</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-link-assembly</artifactId>
+      <version>${version.pax.exam}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.framework</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
+      <version>4.3.1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <testResources>
+      <testResource>
+        <directory>src/test-resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>failsafe</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>2.22.0</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/xstream-its/src/test-resources/project.properties
+++ b/xstream-its/src/test-resources/project.properties
@@ -1,0 +1,1 @@
+project.version=${project.version}

--- a/xstream-its/src/test/com/thoughtworks/xstream/XStreamIT.java
+++ b/xstream-its/src/test/com/thoughtworks/xstream/XStreamIT.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2003, 2004, 2005, 2006 Joe Walnes.
+ * Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018 XStream Committers.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ * Created on 26. September 2003 by Joe Walnes
+ */
+package com.thoughtworks.xstream;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerMethod;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerMethod.class)
+public class XStreamIT
+{
+  @Inject
+  BundleContext bundleContext;
+
+  @Configuration
+  public Option[] config() throws Exception {
+    Properties properties = new Properties();
+    try (InputStream is = getClass().getResourceAsStream("/project.properties")) {
+      properties.load(is);
+    }
+    String xstreamVersion = properties.getProperty("project.version");
+
+    return options(
+        junitBundles(),
+        mavenBundle().groupId("com.thoughtworks.xstream").artifactId("xstream").version(xstreamVersion)
+    );
+  }
+
+  @Test
+  public void smokeTest() {
+    assertNotNull("BundleContext was not injected", bundleContext);
+
+    boolean xstreamBundleFound = false;
+    int xstreamBundleState = -1;
+    for (Bundle bundle : bundleContext.getBundles()) {
+      if ("xstream".equals(bundle.getSymbolicName())) {
+        xstreamBundleFound = true;
+        xstreamBundleState = bundle.getState();
+      }
+    }
+
+    assertTrue("XStream bundle was not loaded", xstreamBundleFound);
+    assertEquals(
+        format("XStream bundle was not active (was: %d)", xstreamBundleState),
+        xstreamBundleState, Bundle.ACTIVE
+    );
+  }
+}


### PR DESCRIPTION
After the discussion on https://github.com/x-stream/xstream/pull/156 I thought maybe it would be helpful to add a quick test that loads xstream in an OSGi container. There may be other ways to pull this off, but this is the way that I'm familiar with. It's pretty straightforward - it pretty closely aligns with the tutorial here:
https://ops4j1.jira.com/wiki/spaces/PAXEXAM4/pages/54263846/Getting+Started+with+OSGi+Tests

I am not sure about formatting styles, headers, etc. So just let me know if there are some updates to get in-line. 