### PR TITLE
Sometimes, an instance is casted to a specific subtype, but methods

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/converters/extended/ToAttributedValueConverter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/extended/ToAttributedValueConverter.java
@@ -158,9 +158,9 @@ public class ToAttributedValueConverter implements Converter {
                     throw exception;
                 }
 
-                ConverterMatcher converter = Enum.class.isAssignableFrom(type) ? (ConverterMatcher)enumMapper
-                    .getConverterFromItemType(null, type, null) : (ConverterMatcher)mapper.getLocalConverter(definedIn,
-                    fieldName);
+                ConverterMatcher converter = Enum.class.isAssignableFrom(type) ? enumMapper
+					.getConverterFromItemType(null, type, null) : mapper.getLocalConverter(definedIn,
+						fieldName);
                 if (converter == null) {
                     converter = lookup.lookupConverterForType(type);
                 }
@@ -244,9 +244,9 @@ public class ToAttributedValueConverter implements Converter {
 
                 Class<?> type = field.getType();
                 final Class<?> declaringClass = field.getDeclaringClass();
-                ConverterMatcher converter = Enum.class.isAssignableFrom(type) ? (ConverterMatcher)enumMapper
-                    .getConverterFromItemType(null, type, null) : (ConverterMatcher)mapper.getLocalConverter(
-                    declaringClass, fieldName);
+                ConverterMatcher converter = Enum.class.isAssignableFrom(type) ? enumMapper
+					.getConverterFromItemType(null, type, null) : mapper.getLocalConverter(
+						declaringClass, fieldName);
                 if (converter == null) {
                     converter = lookup.lookupConverterForType(type);
                 }

--- a/xstream/src/java/com/thoughtworks/xstream/converters/reflection/AbstractReflectionConverter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/reflection/AbstractReflectionConverter.java
@@ -226,7 +226,7 @@ public abstract class AbstractReflectionConverter implements Converter, Caching 
                     for (final Iterator<?> iter = isArray
                         ? new ArrayIterator(info.value)
                         : isCollection
-                            ? ((Collection<?>)info.value).iterator()
+                            ? ((Iterable<?>)info.value).iterator()
                             : isEntry
                                 ? ((Map<?, ?>)info.value).entrySet().iterator()
                                 : ((Map<?, ?>)info.value).values().iterator(); iter.hasNext();) {

--- a/xstream/src/java/com/thoughtworks/xstream/converters/reflection/CGLIBEnhancedConverter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/reflection/CGLIBEnhancedConverter.java
@@ -262,7 +262,7 @@ public class CGLIBEnhancedConverter extends SerializableConverter {
                     }
                     callbackIndexMap.put(null, method);
                     calledMethod.invoke(source, parameterTypes == null
-                        ? (Object[])null
+                        ? null
                         : createNullArguments(parameterTypes));
                 } catch (final IllegalAccessException e) {
                     final ObjectAccessException exception = new ObjectAccessException("Cannot access method", e);

--- a/xstream/src/java/com/thoughtworks/xstream/converters/reflection/FieldDictionary.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/reflection/FieldDictionary.java
@@ -97,7 +97,7 @@ public class FieldDictionary implements Caching {
      */
     public Field fieldOrNull(final Class<?> cls, final String name, final Class<?> definedIn) {
         final Map<?, Field> fields = buildMap(cls, definedIn != null);
-        final Field field = fields.get(definedIn != null ? (Object)new FieldKey(name, definedIn, -1) : (Object)name);
+        final Field field = fields.get(definedIn != null ? new FieldKey(name, definedIn, -1) : name);
         return field;
     }
 

--- a/xstream/src/java/com/thoughtworks/xstream/converters/reflection/SunUnsafeReflectionProvider.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/reflection/SunUnsafeReflectionProvider.java
@@ -68,19 +68,19 @@ public class SunUnsafeReflectionProvider extends SunLimitedUnsafeReflectionProvi
             final Class<?> type = field.getType();
             if (type.isPrimitive()) {
                 if (type.equals(Integer.TYPE)) {
-                    unsafe.putInt(object, offset, ((Integer)value).intValue());
+                    unsafe.putInt(object, offset, ((Number)value).intValue());
                 } else if (type.equals(Long.TYPE)) {
-                    unsafe.putLong(object, offset, ((Long)value).longValue());
+                    unsafe.putLong(object, offset, ((Number)value).longValue());
                 } else if (type.equals(Short.TYPE)) {
-                    unsafe.putShort(object, offset, ((Short)value).shortValue());
+                    unsafe.putShort(object, offset, ((Number)value).shortValue());
                 } else if (type.equals(Character.TYPE)) {
                     unsafe.putChar(object, offset, ((Character)value).charValue());
                 } else if (type.equals(Byte.TYPE)) {
-                    unsafe.putByte(object, offset, ((Byte)value).byteValue());
+                    unsafe.putByte(object, offset, ((Number)value).byteValue());
                 } else if (type.equals(Float.TYPE)) {
-                    unsafe.putFloat(object, offset, ((Float)value).floatValue());
+                    unsafe.putFloat(object, offset, ((Number)value).floatValue());
                 } else if (type.equals(Double.TYPE)) {
-                    unsafe.putDouble(object, offset, ((Double)value).doubleValue());
+                    unsafe.putDouble(object, offset, ((Number)value).doubleValue());
                 } else if (type.equals(Boolean.TYPE)) {
                     unsafe.putBoolean(object, offset, ((Boolean)value).booleanValue());
                 } else {

--- a/xstream/src/java/com/thoughtworks/xstream/core/util/CustomObjectInputStream.java
+++ b/xstream/src/java/com/thoughtworks/xstream/core/util/CustomObjectInputStream.java
@@ -151,7 +151,7 @@ public class CustomObjectInputStream extends ObjectInputStream {
 
     @Override
     public byte readByte() throws IOException {
-        return ((Byte)peekCallback().readFromStream()).byteValue();
+        return ((Number)peekCallback().readFromStream()).byteValue();
     }
 
     @Override
@@ -161,7 +161,7 @@ public class CustomObjectInputStream extends ObjectInputStream {
 
     @Override
     public int readInt() throws IOException {
-        return ((Integer)peekCallback().readFromStream()).intValue();
+        return ((Number)peekCallback().readFromStream()).intValue();
     }
 
     @Override
@@ -171,22 +171,22 @@ public class CustomObjectInputStream extends ObjectInputStream {
 
     @Override
     public float readFloat() throws IOException {
-        return ((Float)peekCallback().readFromStream()).floatValue();
+        return ((Number)peekCallback().readFromStream()).floatValue();
     }
 
     @Override
     public double readDouble() throws IOException {
-        return ((Double)peekCallback().readFromStream()).doubleValue();
+        return ((Number)peekCallback().readFromStream()).doubleValue();
     }
 
     @Override
     public long readLong() throws IOException {
-        return ((Long)peekCallback().readFromStream()).longValue();
+        return ((Number)peekCallback().readFromStream()).longValue();
     }
 
     @Override
     public short readShort() throws IOException {
-        return ((Short)peekCallback().readFromStream()).shortValue();
+        return ((Number)peekCallback().readFromStream()).shortValue();
     }
 
     @Override
@@ -259,7 +259,7 @@ public class CustomObjectInputStream extends ObjectInputStream {
 
         @Override
         public byte get(final String name, final byte val) {
-            return defaulted(name) ? val : ((Byte)get(name)).byteValue();
+            return defaulted(name) ? val : ((Number)get(name)).byteValue();
         }
 
         @Override
@@ -269,27 +269,27 @@ public class CustomObjectInputStream extends ObjectInputStream {
 
         @Override
         public double get(final String name, final double val) {
-            return defaulted(name) ? val : ((Double)get(name)).doubleValue();
+            return defaulted(name) ? val : ((Number)get(name)).doubleValue();
         }
 
         @Override
         public float get(final String name, final float val) {
-            return defaulted(name) ? val : ((Float)get(name)).floatValue();
+            return defaulted(name) ? val : ((Number)get(name)).floatValue();
         }
 
         @Override
         public int get(final String name, final int val) {
-            return defaulted(name) ? val : ((Integer)get(name)).intValue();
+            return defaulted(name) ? val : ((Number)get(name)).intValue();
         }
 
         @Override
         public long get(final String name, final long val) {
-            return defaulted(name) ? val : ((Long)get(name)).longValue();
+            return defaulted(name) ? val : ((Number)get(name)).longValue();
         }
 
         @Override
         public short get(final String name, final short val) {
-            return defaulted(name) ? val : ((Short)get(name)).shortValue();
+            return defaulted(name) ? val : ((Number)get(name)).shortValue();
         }
 
         @Override

--- a/xstream/src/java/com/thoughtworks/xstream/io/binary/Token.java
+++ b/xstream/src/java/com/thoughtworks/xstream/io/binary/Token.java
@@ -117,10 +117,10 @@ public abstract class Token {
         }
         switch (idType) {
         case ID_ONE_BYTE:
-            out.writeByte((byte)id + Byte.MIN_VALUE);
+            out.writeByte((int)id + Byte.MIN_VALUE);
             break;
         case ID_TWO_BYTES:
-            out.writeShort((short)id + Short.MIN_VALUE);
+            out.writeShort((int)id + Short.MIN_VALUE);
             break;
         case ID_FOUR_BYTES:
             out.writeInt((int)id + Integer.MIN_VALUE);
@@ -180,7 +180,7 @@ public abstract class Token {
                 idType = ID_ONE_BYTE;
             } else if (id <= Short.MAX_VALUE - Short.MIN_VALUE) {
                 idType = ID_TWO_BYTES;
-            } else if (id <= (long)Integer.MAX_VALUE - (long)Integer.MIN_VALUE) { // cast to long to prevent overflow
+            } else if (id <= Integer.MAX_VALUE - (long)Integer.MIN_VALUE) { // cast to long to prevent overflow
                 idType = ID_FOUR_BYTES;
             } else {
                 idType = ID_EIGHT_BYTES;

--- a/xstream/src/java/com/thoughtworks/xstream/io/xml/AbstractPullReader.java
+++ b/xstream/src/java/com/thoughtworks/xstream/io/xml/AbstractPullReader.java
@@ -152,7 +152,7 @@ public abstract class AbstractPullReader extends AbstractXmlReader {
     }
 
     private Event readRealEvent() {
-        final Event event = pool.hasStuff() ? (Event)pool.pop() : new Event();
+        final Event event = pool.hasStuff() ? pool.pop() : new Event();
         event.type = pullNextEvent();
         if (event.type == TEXT) {
             event.value = pullText();

--- a/xstream/src/java/com/thoughtworks/xstream/io/xml/xppdom/XppDom.java
+++ b/xstream/src/java/com/thoughtworks/xstream/io/xml/xppdom/XppDom.java
@@ -78,7 +78,7 @@ public class XppDom implements Serializable {
     }
 
     public String getAttribute(final String name) {
-        return null != attributes ? (String)attributes.get(name) : null;
+        return null != attributes ? attributes.get(name) : null;
     }
 
     public void setAttribute(final String name, final String value) {

--- a/xstream/src/java/com/thoughtworks/xstream/mapper/CachingMapper.java
+++ b/xstream/src/java/com/thoughtworks/xstream/mapper/CachingMapper.java
@@ -41,7 +41,7 @@ public class CachingMapper extends MapperWrapper implements Caching {
             if (cached instanceof Class) {
                 return (Class<?>)cached;
             }
-            throw (XStreamException)cached;
+            throw (RuntimeException)cached;
         }
 
         try {

--- a/xstream/src/test/com/thoughtworks/acceptance/ImplicitArrayTest.java
+++ b/xstream/src/test/com/thoughtworks/acceptance/ImplicitArrayTest.java
@@ -465,9 +465,9 @@ public class ImplicitArrayTest extends AbstractAcceptanceTest {
 
     public void testWithHiddenArray() {
         final Area area = new Area();
-        ((Farm)area).animals = new Animal[2];
-        ((Farm)area).animals[0] = new Animal("Cow");
-        ((Farm)area).animals[1] = new Animal("Sheep");
+        area.animals = new Animal[2];
+        area.animals[0] = new Animal("Cow");
+        area.animals[1] = new Animal("Sheep");
         area.animals = new Animal[2];
         area.animals[0] = new Animal("Falcon");
         area.animals[1] = new Animal("Sparrow");
@@ -495,9 +495,9 @@ public class ImplicitArrayTest extends AbstractAcceptanceTest {
 
     public void testWithHiddenArrayAndDifferentAlias() {
         final Area area = new Area();
-        ((Farm)area).animals = new Animal[2];
-        ((Farm)area).animals[0] = new Animal("Cow");
-        ((Farm)area).animals[1] = new Animal("Sheep");
+        area.animals = new Animal[2];
+        area.animals[0] = new Animal("Cow");
+        area.animals[1] = new Animal("Sheep");
         area.animals = new Animal[2];
         area.animals[0] = new Animal("Falcon");
         area.animals[1] = new Animal("Sparrow");
@@ -525,9 +525,9 @@ public class ImplicitArrayTest extends AbstractAcceptanceTest {
 
     public void testDoesNotInheritFromHiddenArrayOfSuperclass() {
         final Area area = new Area();
-        ((Farm)area).animals = new Animal[2];
-        ((Farm)area).animals[0] = new Animal("Cow");
-        ((Farm)area).animals[1] = new Animal("Sheep");
+        area.animals = new Animal[2];
+        area.animals[0] = new Animal("Cow");
+        area.animals[1] = new Animal("Sheep");
         area.animals = new Animal[2];
         area.animals[0] = new Animal("Falcon");
         area.animals[1] = new Animal("Sparrow");
@@ -556,9 +556,9 @@ public class ImplicitArrayTest extends AbstractAcceptanceTest {
 
     public void testDoesNotPropagateToHiddenArrayOfSuperclass() {
         final Area area = new Area();
-        ((Farm)area).animals = new Animal[2];
-        ((Farm)area).animals[0] = new Animal("Cow");
-        ((Farm)area).animals[1] = new Animal("Sheep");
+        area.animals = new Animal[2];
+        area.animals[0] = new Animal("Cow");
+        area.animals[1] = new Animal("Sheep");
         area.animals = new Animal[2];
         area.animals[0] = new Animal("Falcon");
         area.animals[1] = new Animal("Sparrow");
@@ -597,12 +597,12 @@ public class ImplicitArrayTest extends AbstractAcceptanceTest {
 
     public void testWithDoubleHiddenArray() {
         final Country country = new Country();
-        ((Farm)country).animals = new Animal[2];
-        ((Farm)country).animals[0] = new Animal("Cow");
-        ((Farm)country).animals[1] = new Animal("Sheep");
-        ((Area)country).animals = new Animal[2];
-        ((Area)country).animals[0] = new Animal("Falcon");
-        ((Area)country).animals[1] = new Animal("Sparrow");
+        country.animals = new Animal[2];
+        country.animals[0] = new Animal("Cow");
+        country.animals[1] = new Animal("Sheep");
+        country.animals = new Animal[2];
+        country.animals[0] = new Animal("Falcon");
+        country.animals[1] = new Animal("Sparrow");
         country.animals = new Animal[2];
         country.animals[0] = new Animal("Wale");
         country.animals[1] = new Animal("Dolphin");

--- a/xstream/src/test/com/thoughtworks/acceptance/ImplicitCollectionTest.java
+++ b/xstream/src/test/com/thoughtworks/acceptance/ImplicitCollectionTest.java
@@ -757,8 +757,8 @@ public class ImplicitCollectionTest extends AbstractAcceptanceTest {
         final Country country = new Country();
         country.add(new Animal("Cow"));
         country.add(new Animal("Sheep"));
-        ((Area)country).animals.add(new Animal("Falcon"));
-        ((Area)country).animals.add(new Animal("Sparrow"));
+        country.animals.add(new Animal("Falcon"));
+        country.animals.add(new Animal("Sparrow"));
         country.animals.add(new Animal("Wale"));
         country.animals.add(new Animal("Dolphin"));
 

--- a/xstream/src/test/com/thoughtworks/acceptance/ImplicitTest.java
+++ b/xstream/src/test/com/thoughtworks/acceptance/ImplicitTest.java
@@ -279,28 +279,28 @@ public class ImplicitTest extends AbstractAcceptanceTest {
             + "</implicits>";
 
         final AllHidingImplicitTypes implicits = new AllHidingImplicitTypes();
-        ((AllImplicitTypes)implicits).aArray[0] = new AllImplicitTypes.A();
-        ((AllImplicitTypes)implicits).aArray[0].val = 1;
-        ((AllImplicitTypes)implicits).aArray[1] = new AllImplicitTypes.A();
-        ((AllImplicitTypes)implicits).aArray[1].val = 2;
+        implicits.aArray[0] = new AllImplicitTypes.A();
+        implicits.aArray[0].val = 1;
+        implicits.aArray[1] = new AllImplicitTypes.A();
+        implicits.aArray[1].val = 2;
         implicits.aArray[0] = new AllImplicitTypes.A();
         implicits.aArray[0].val = 7;
         implicits.aArray[1] = new AllImplicitTypes.A();
         implicits.aArray[1].val = 8;
-        ((AllImplicitTypes)implicits).bList.add(new AllImplicitTypes.B());
-        ((AllImplicitTypes)implicits).bList.get(0).val = 3;
-        ((AllImplicitTypes)implicits).bList.add(new AllImplicitTypes.B());
-        ((AllImplicitTypes)implicits).bList.get(1).val = 4;
+        implicits.bList.add(new AllImplicitTypes.B());
+        implicits.bList.get(0).val = 3;
+        implicits.bList.add(new AllImplicitTypes.B());
+        implicits.bList.get(1).val = 4;
         implicits.bList.add(new AllImplicitTypes.B());
         implicits.bList.get(0).val = 9;
         implicits.bList.add(new AllImplicitTypes.B());
         implicits.bList.get(1).val = 10;
         AllImplicitTypes.C c = new AllImplicitTypes.C();
         c.val = new Integer(5);
-        ((AllImplicitTypes)implicits).cMap.put(c.val, c);
+        implicits.cMap.put(c.val, c);
         c = new AllImplicitTypes.C();
         c.val = new Integer(6);
-        ((AllImplicitTypes)implicits).cMap.put(c.val, c);
+        implicits.cMap.put(c.val, c);
         c = new AllImplicitTypes.C();
         c.val = new Integer(11);
         implicits.cMap.put(c.val, c);
@@ -308,7 +308,7 @@ public class ImplicitTest extends AbstractAcceptanceTest {
         c.val = new Integer(12);
         implicits.cMap.put(c.val, c);
         assertBothWays(implicits, expected);
-        implicits.separator1 = implicits.separator2 = ((AllHidingTypes)implicits).separator = implicits.separator =
+        implicits.separator1 = implicits.separator2 = implicits.separator = implicits.separator =
                 null;
         assertBothWays(implicits, stripSeparator(expected));
     }

--- a/xstream/src/test/com/thoughtworks/acceptance/LambdaTest.java
+++ b/xstream/src/test/com/thoughtworks/acceptance/LambdaTest.java
@@ -38,7 +38,7 @@ public class LambdaTest extends AbstractAcceptanceTest {
 
     public void testLambdaExpression() {
         final LambdaKeeper keeper = new LambdaKeeper();
-        keeper.keep((Callable<String>)() -> "result");
+        keeper.keep(() -> "result");
 
         final String expected = "" + "<keeper>\n" + "  <callable class=\"null\"/>\n" + "</keeper>";
         xstream.alias("keeper", LambdaKeeper.class);
@@ -50,7 +50,7 @@ public class LambdaTest extends AbstractAcceptanceTest {
 
     public void testSerializableLambdaExpression() {
         final LambdaKeeper keeper = new LambdaKeeper();
-        keeper.keep((Callable<String> & Serializable)() -> "result");
+        keeper.keep(() -> "result");
 
         final String expected = ""
             + "<keeper>\n"
@@ -79,7 +79,7 @@ public class LambdaTest extends AbstractAcceptanceTest {
 
     public void testReferencedLambdaExpression() {
         final LambdaKeeper keeper = new LambdaKeeper();
-        keeper.keep((Callable<String> & Serializable)() -> "result");
+        keeper.keep(() -> "result");
         keeper.reference();
 
         final String expected = ""

--- a/xstream/src/test/com/thoughtworks/acceptance/LocalConverterTest.java
+++ b/xstream/src/test/com/thoughtworks/acceptance/LocalConverterTest.java
@@ -91,7 +91,7 @@ public class LocalConverterTest extends AbstractAcceptanceTest {
 
         @Override
         public String toString(final Object obj) {
-            return Integer.toHexString(((Integer)obj).intValue());
+            return Integer.toHexString(((Number)obj).intValue());
         }
     }
 

--- a/xstream/src/test/com/thoughtworks/acceptance/XStream12CompatibilityTest.java
+++ b/xstream/src/test/com/thoughtworks/acceptance/XStream12CompatibilityTest.java
@@ -45,13 +45,13 @@ public class XStream12CompatibilityTest extends AbstractAcceptanceTest {
         String name;
 
         ChildClass(final String parent, final String child) {
-            ((ParentClass)this).name = parent;
+            this.name = parent;
             name = child;
         }
 
         @Override
         public String toString() {
-            return ((ParentClass)this).name + "/" + name;
+            return this.name + "/" + name;
         }
     }
 

--- a/xstream/src/test/com/thoughtworks/xstream/converters/basic/DateConverterTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/converters/basic/DateConverterTest.java
@@ -66,7 +66,7 @@ public class DateConverterTest extends TestCase {
     }
 
     public void testUnmarshalsOldXStreamDatesThatLackMillisecond() {
-        converter = new DateConverter((TimeZone)null); // use default TZ
+        converter = new DateConverter(null); // use default TZ
         final Date expected = (Date)converter.fromString("2004-02-22 15:16:04.0 EST");
 
         assertEquals(expected, converter.fromString("2004-02-22 15:16:04.0 EST"));
@@ -99,7 +99,7 @@ public class DateConverterTest extends TestCase {
     }
 
     public void testUnmarshalsDateWithDifferentDefaultTimeZones() throws ParseException {
-        converter = new DateConverter((TimeZone)null); // use default TZ
+        converter = new DateConverter(null); // use default TZ
         final Calendar cal = Calendar.getInstance();
         cal.clear();
         cal.set(2004, Calendar.FEBRUARY, 23, 1, 46, 4);
@@ -183,7 +183,7 @@ public class DateConverterTest extends TestCase {
     }
 
     public void testDatesIn70sInTimeZoneGMT() throws ParseException {
-        converter = new DateConverter((TimeZone)null); // use default TZ
+        converter = new DateConverter(null); // use default TZ
 
         final String pattern = "yyyy-MM-dd HH:mm:ss.S z";
         final SimpleDateFormat format;

--- a/xstream/src/test/com/thoughtworks/xstream/converters/enums/EnumConverterTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/converters/enums/EnumConverterTest.java
@@ -57,11 +57,11 @@ public class EnumConverterTest extends TestCase {
 
         in = PolymorphicEnum.A;
         out = xstream.<PolymorphicEnum>fromXML(xstream.toXML(in));
-        assertEquals("apple", ((Fruit)out).fruit()); // see Bug ID: 6522780
+        assertEquals("apple", out.fruit()); // see Bug ID: 6522780
 
         in = PolymorphicEnum.B;
         out = xstream.<PolymorphicEnum>fromXML(xstream.toXML(in));
-        assertEquals("banana", ((Fruit)out).fruit()); // see Bug ID: 6522780
+        assertEquals("banana", out.fruit()); // see Bug ID: 6522780
     }
 
 }


### PR DESCRIPTION
invoked or fields used from the casted instance are actually defined by
some supertype. In that case cast to too specific type introduces an
unnecessary coupling to the code and limits its extensibility.