### PR TITLE
Replacement of a failed central storage bin address.

### DIFF
--- a/xstream-distribution/src/content/download.html
+++ b/xstream-distribution/src/content/download.html
@@ -21,17 +21,17 @@
     <h1 id="stable">Stable Version: <span class="version">1.4.11.1</span></h1>
 
     <ul>
-      <li><b><a href="http://repo1.maven.org/maven2/com/thoughtworks/xstream/xstream-distribution/1.4.11.1/xstream-distribution-1.4.11.1-bin.zip">Binary distribution:</a></b>
+      <li><b><a href="https://repo1.maven.org/maven2/com/thoughtworks/xstream/xstream-distribution/1.4.11.1/xstream-distribution-1.4.11.1-bin.zip">Binary distribution:</a></b>
       Contains the XStream jar files, the Hibernate and Benchmark modules and all the dependencies.</li>
-      <li><b><a href="http://repo1.maven.org/maven2/com/thoughtworks/xstream/xstream-distribution/1.4.11.1/xstream-distribution-1.4.11.1-src.zip">Source distribution:</a></b>
+      <li><b><a href="https://repo1.maven.org/maven2/com/thoughtworks/xstream/xstream-distribution/1.4.11.1/xstream-distribution-1.4.11.1-src.zip">Source distribution:</a></b>
       Contains the complete XStream project as if checked out from the Subversion version tag.</li>
-      <li><b><a href="http://repo1.maven.org/maven2/com/thoughtworks/xstream/xstream/1.4.11.1/xstream-1.4.11.1.jar">XStream Core only:</a>
+      <li><b><a href="https://repo1.maven.org/maven2/com/thoughtworks/xstream/xstream/1.4.11.1/xstream-1.4.11.1.jar">XStream Core only:</a>
       The xstream.jar only as it is downloaded automatically when it is referenced as Maven dependency.</b></li>
-      <li><b><a href="http://repo1.maven.org/maven2/com/thoughtworks/xstream/xstream-hibernate/1.4.11.1/xstream-hibernate-1.4.11.1.jar">XStream Hibernate module:</a></b>
+      <li><b><a href="https://repo1.maven.org/maven2/com/thoughtworks/xstream/xstream-hibernate/1.4.11.1/xstream-hibernate-1.4.11.1.jar">XStream Hibernate module:</a></b>
       The xstream-hibernate.jar as it is downloaded automatically when it is referenced as Maven dependency.</li>
-      <li><b><a href="http://repo1.maven.org/maven2/com/thoughtworks/xstream/xstream-jmh/1.4.11.1/xstream-jmh-1.4.11.1-app.zip">XStream JMH module:</a></b>
+      <li><b><a href="https://repo1.maven.org/maven2/com/thoughtworks/xstream/xstream-jmh/1.4.11.1/xstream-jmh-1.4.11.1-app.zip">XStream JMH module:</a></b>
       The xstream-jmh-app.zip as standalone application with start scripts and all required libraries.</li>
-      <li><b><a href="http://repo1.maven.org/maven2/com/thoughtworks/xstream/xstream/1.4.11-java7/xstream-1.4.11-java7.jar">XStream Core for Java 7 only:</a>
+      <li><b><a href="https://repo1.maven.org/maven2/com/thoughtworks/xstream/xstream/1.4.11-java7/xstream-1.4.11-java7.jar">XStream Core for Java 7 only:</a>
       The xstream.jar only <a href="faq.html#Compatibility_Android">without the Java 8 stuff</a> as it is downloaded automatically when it is referenced as Maven dependency.</b></li>
     </ul>
 
@@ -40,8 +40,8 @@
     <p>Previous releases of XStream are also available. However, use of the latest stable version is recommended.</p>
 
     <ul>
-      <li><a href="http://repo1.maven.org/maven2/com/thoughtworks/xstream/xstream/">Previous releases (&gt;= 1.2)</a></li>
-      <li><a href="http://repo1.maven.org/maven2/xstream/xstream/">Previous releases (&lt;= 1.2)</a></li>
+      <li><a href="https://repo1.maven.org/maven2/com/thoughtworks/xstream/xstream/">Previous releases (&gt;= 1.2)</a></li>
+      <li><a href="https://repo1.maven.org/maven2/xstream/xstream/">Previous releases (&lt;= 1.2)</a></li>
     </ul>
 
     <h1 id="optional-deps">Optional Dependencies</h1>
@@ -55,24 +55,24 @@
     <ul>
       <li>Supported XML parsers and packages:
       <ul>
-        <li><a href="http://repo1.maven.org/maven2/xmlpull/xmlpull/1.1.3.1/xmlpull-1.1.3.1.jar">XmlPull</a>, the <a href="http://www.xmlpull.org/">XML pull parser API</a> and factory to detect available implementations.</li>
+        <li><a href="https://repo1.maven.org/maven2/xmlpull/xmlpull/1.1.3.1/xmlpull-1.1.3.1.jar">XmlPull</a>, the <a href="http://www.xmlpull.org/">XML pull parser API</a> and factory to detect available implementations.</li>
         <li><a href="http://www.extreme.indiana.edu/dist/java-repository/xpp3/jars/xpp3_min-1.1.4c.jar">Xpp3</a>, an XML pull parser (recommended).</li>
         <li><a href="http://downloads.sourceforge.net/kxml/kxml2-2.3.0.jar">kXML2</a> or <a href="http://downloads.sourceforge.net/kxml/kxml2-min-2.3.0.jar">kXML2-min</a>, an XML pull parser.</li>
         <li><a href="https://github.com/dom4j/dom4j/releases/download/version-2.0.2/dom4j-2.0.2.jar">DOM4J</a>, easy XML representation and manipulation framework.</li>
         <li><a href="http://www.jdom.org/dist/binary/archive/jdom-1.1.3.zip">JDOM</a>, easy XML representation and manipulation (superseded by JDOM2).</li>
         <li><a href="http://www.jdom.org/dist/binary/jdom-2.0.6.zip">JDOM2</a>, easy XML representation and manipulation, successor of JDOM.</li>
-        <li>StaX, the <a href="http://repo1.maven.org/maven2/stax/stax-1.2.0.jar">reference implementation</a> of the <a href="http://repo1.maven.org/maven2/stax/stax-api-1.0.1.jar">Streaming API for XML</a>.</li>
-        <li><a href="http://repo1.maven.org/maven2/com.fasterxml.woodstox/woodstox-core-5.2.0.jar">Woodstox</a>, an alternate open source StaX implementation.</li>
+        <li>StaX, the <a href="https://repo1.maven.org/maven2/stax/stax/1.2.0/stax-1.2.0.jar">reference implementation</a> of the <a href="https://repo1.maven.org/maven2/stax/stax-api/1.0.1/stax-api-1.0.1.jar">Streaming API for XML</a>.</li>
+        <li><a href="https://repo1.maven.org/maven2/com/fasterxml/woodstox/woodstox-core/5.2.0/woodstox-core-5.2.0.jar">Woodstox</a>, an alternate open source StaX implementation.</li>
         <li><a href="http://www.cafeconleche.org/XOM/xom-1.3.2.zip">XOM</a>, another alternative XML API.</li>
       </ul>
       </li>
         <li>Other optional 3rd party dependencies:
         <ul>
-      	  <li><a href="http://repo1.maven.org/maven2/javax/activation/jaxax.activation-api/1.2.0/jaxax.activation-api-1.2.0.jar">Java Activation module</a> for the ActivationDataFlavorConverter. The dependency is required for the Java 11 runtime.</li>
+      	  <li><a href="https://repo1.maven.org/maven2/javax/activation/jaxax.activation-api/1.2.0/jaxax.activation-api-1.2.0.jar">Java Activation module</a> for the ActivationDataFlavorConverter. The dependency is required for the Java 11 runtime.</li>
       	  <li><a href="https://github.com/JodaOrg/joda-time/releases/download/v2.10.1/joda-time-2.10.1-dist.zip">Joda Time</a> for optional ISO8601 date/time converters in JDK 1.7 or below.</li>
       	  <li><a href="http://downloads.sourceforge.net/cglib/cglib-nodep-2.2.jar">CGLIB</a> for optional support of some proxies generated with the CGLIB Enhancer.</li>
-      	  <li><a href="http://repo1.maven.org/maven2/org/codehaus/jettison/jettison/1.2/jettison-1.2.jar">Jettison</a> for serialization and deserialization support with JSON. Note, that newer versions 1.3.x are no longer compatible with XStream.</li>
-      	  <li><a href="http://repo1.maven.org/maven2/org/codehaus/jettison/jettison/1.0/jettison-1.0.jar">Jettison 1.0.1</a> for serialization and deserialization support with JSON in JDK 1.4. Note, that newer version 1.1 is not compatible with XStream.</li>
+      	  <li><a href="https://repo1.maven.org/maven2/org/codehaus/jettison/jettison/1.2/jettison-1.2.jar">Jettison</a> for serialization and deserialization support with JSON. Note, that newer versions 1.3.x are no longer compatible with XStream.</li>
+      	  <li><a href="https://repo1.maven.org/maven2/org/codehaus/jettison/jettison/1.0/jettison-1.0.jar">Jettison 1.0.1</a> for serialization and deserialization support with JSON in JDK 1.4. Note, that newer version 1.1 is not compatible with XStream.</li>
         </ul>
       </li>
     </ul>
@@ -82,15 +82,15 @@
     <ul>
     	<li>Supported Hibernate versions:
     	<ul>
-      		<li><a href="http://repo1.maven.org/maven2/org/hibernate/hibernate-core/4.2.5.Final/hibernate-core-4.2.5.Final.jar">Hibernate Core 4.2.5</a>, for Java 6 or higher.</li>
-      		<li><a href="http://repo1.maven.org/maven2/org/hibernate/hibernate-core/3.6.6.Final/hibernate-core-3.6.6.Final.jar">Hibernate Core 3.6.6</a>, for Java 5.</li>
-      		<li><a href="http://repo1.maven.org/maven2/org/hibernate/hibernate-core/3.3.2.GA/hibernate-core-3.3.2.GA.jar">Hibernate Core 3.3.2</a>, for Java 1.4.</li>
+      		<li><a href="https://repo1.maven.org/maven2/org/hibernate/hibernate-core/4.2.5.Final/hibernate-core-4.2.5.Final.jar">Hibernate Core 4.2.5</a>, for Java 6 or higher.</li>
+      		<li><a href="https://repo1.maven.org/maven2/org/hibernate/hibernate-core/3.6.6.Final/hibernate-core-3.6.6.Final.jar">Hibernate Core 3.6.6</a>, for Java 5.</li>
+      		<li><a href="https://repo1.maven.org/maven2/org/hibernate/hibernate-core/3.3.2.GA/hibernate-core-3.3.2.GA.jar">Hibernate Core 3.3.2</a>, for Java 1.4.</li>
       	</ul>
       	</li>
     	<li>Supported Hibernate Envers versions:
     	<ul>
-      		<li><a href="http://repo1.maven.org/maven2/org/hibernate/hibernate-envers/4.2.5.Final/hibernate-envers-4.2.5.Final.jar">Hibernate Envers 4.2.5</a>, for Java 6 or higher.</li>
-      		<li><a href="http://repo1.maven.org/maven2/org/hibernate/hibernate-envers/3.6.6.Final/hibernate-envers-3.6.6.Final.jar">Hibernate Envers 3.6.6</a>, for Java 5.</li>
+      		<li><a href="https://repo1.maven.org/maven2/org/hibernate/hibernate-envers/4.2.5.Final/hibernate-envers-4.2.5.Final.jar">Hibernate Envers 4.2.5</a>, for Java 6 or higher.</li>
+      		<li><a href="https://repo1.maven.org/maven2/org/hibernate/hibernate-envers/3.6.6.Final/hibernate-envers-3.6.6.Final.jar">Hibernate Envers 3.6.6</a>, for Java 5.</li>
       	</ul>
       	</li>
     </ul>
@@ -100,8 +100,8 @@
     <ul>
     	<li>JMH dependencies:
     	<ul>
-      		<li><a href="http://repo1.maven.org/maven2/org/openjdk/jmh-core/1.19/jmh-core-1.19.jar">JMH Core 1.19</a>, for Java 6 or higher.</li>
-      		<li><a href="http://repo1.maven.org/maven2/org/openjdk/jmh-generator-annprocess/1.19/jmh-generator-annprocess-1.19.jar">JMH Generator Annotation Processor 1.19</a>, for Java 6 or higher.</li>
+      		<li><a href="https://repo1.maven.org/maven2/org/openjdk/jmh/jmh-core/1.19/jmh-core-1.19.jar">JMH Core 1.19</a>, for Java 6 or higher.</li>
+      		<li><a href="https://repo1.maven.org/maven2/org/openjdk/jmh/jmh-generator-annprocess/1.19/jmh-generator-annprocess-1.19.jar">JMH Generator Annotation Processor 1.19</a>, for Java 6 or higher.</li>
       	</ul>
       	</li>
     </ul>


### PR DESCRIPTION
Effective January 15, 2020. The central storage warehouse no longer supports insecure communication via HTTP, and requires that all requests to the repository be encrypted via HTTPS.