### PR TITLE
Unneeded contention in StringConverter

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/converters/basic/StringConverter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/basic/StringConverter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2003, 2004, 2005 Joe Walnes.
- * Copyright (C) 2006, 2007, 2011, 2014, 2015, 2018 XStream Committers.
+ * Copyright (C) 2006, 2007, 2011, 2014, 2015, 2018 2020 XStream Committers.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -37,7 +37,8 @@ public class StringConverter extends AbstractSingleValueConverter {
 
     /**
      * A Map to store strings as long as needed to map similar strings onto the same instance and conserve memory. The
-     * map can be set from the outside during construction, so it can be a LRU map or a weak map, synchronized or not.
+     * map can be set from the outside during construction.
+     * Use ConcurrentMap to reduce unneeded contention.
      */
     private final ConcurrentMap<String, String> cache;
     private final int lengthLimit;

--- a/xstream/src/test/com/thoughtworks/xstream/converters/extended/StringConverterTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/converters/extended/StringConverterTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 XStream Committers.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ * Created on 12. Mar 2020 by Zezeng Wang
+ */
+
+package com.thoughtworks.xstream.converters.extended;
+
+
+import com.thoughtworks.xstream.converters.SingleValueConverter;
+import com.thoughtworks.xstream.converters.SingleValueConverterWrapper;
+import com.thoughtworks.xstream.converters.basic.StringConverter;
+
+import junit.framework.TestCase;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+
+/**
+ * Tests {@link StringConverter}.
+ */
+public class StringConverterTest extends TestCase {
+
+    /**
+     * Tests use cache.
+     */
+    public void testUseStringConverterCache() {
+        final String str1 = "Use cache";
+        final String str2 = new String("Use cache");
+        assertFalse(str1 == str2);
+        final ConcurrentMap<String,String> map = new ConcurrentHashMap<>();
+        map.put(str1, str1);
+
+        // Using the parameter map constructor
+        final SingleValueConverter converter = new SingleValueConverterWrapper(new StringConverter(map));
+        assertTrue(converter.fromString(str2) == map.get(str1));// Cached value
+
+        // Using the parameter Int 38 constructor
+        final SingleValueConverter converter2 = new SingleValueConverterWrapper(new StringConverter(38));
+        assertTrue(converter2.fromString(str2) == converter2.fromString(str1));
+    }
+
+    /**
+     * Tests not cached when the length exceeds 38 or null.
+     */
+    public void testNotCacheOverLengthOrNull() {
+        final String str1 = "Not cacheNot cacheNot cacheNot cacheNot cache";
+        final String str2 = new String("Not cacheNot cacheNot cacheNot cacheNot cache");
+        assertFalse(str1 == str2);
+        final ConcurrentMap<String,String> map = new ConcurrentHashMap<>();
+        map.put(str1, str1);
+        final SingleValueConverter converter = new SingleValueConverterWrapper(new StringConverter(map));
+        assertFalse(converter.fromString(str2) == map.get(str1));// Non-cached value
+
+        final SingleValueConverter converter2 = new SingleValueConverterWrapper(new StringConverter(null));
+        assertTrue(converter2.fromString(str2) == str2);// Original value
+    }
+}


### PR DESCRIPTION
The calling frequency of StringConverter is still very high. I am very optimistic about the concurrenthashmap compared to the synchronized weakcache.