### PR TITLE
Modify some uninitialized StringBuilder classes

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/converters/ErrorWritingException.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/ErrorWritingException.java
@@ -117,7 +117,8 @@ public abstract class ErrorWritingException extends XStreamException implements 
 
     @Override
     public String getMessage() {
-        final StringBuilder result = new StringBuilder();
+        final int length = SEPARATOR.length() + (stuff.keySet().size() * 20);
+        final StringBuilder result = new StringBuilder(super.getMessage() != null ? super.getMessage().length() + length : length);
         if (super.getMessage() != null) {
             result.append(super.getMessage());
         }

--- a/xstream/src/java/com/thoughtworks/xstream/converters/ErrorWritingException.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/ErrorWritingException.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2003, 2004, 2005 Joe Walnes.
- * Copyright (C) 2006, 2007, 2008, 2009, 2011, 2014, 2015, 2016 XStream Committers.
+ * Copyright (C) 2006, 2007, 2008, 2009, 2011, 2014, 2015, 2016, 2020 XStream Committers.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD

--- a/xstream/src/test/com/thoughtworks/xstream/converters/extended/ThrowableConverterTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/converters/extended/ThrowableConverterTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2004, 2005 Joe Walnes.
- * Copyright (C) 2006, 2007, 2018, 2019 XStream Committers.
+ * Copyright (C) 2006, 2007, 2018, 2019, 2020 XStream Committers.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD

--- a/xstream/src/test/com/thoughtworks/xstream/converters/extended/ThrowableConverterTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/converters/extended/ThrowableConverterTest.java
@@ -210,8 +210,8 @@ public class ThrowableConverterTest extends AbstractAcceptanceTest {
     }
 
     private static void assertArrayEquals(final Object[] expected, final Object[] actual) {
-        final StringBuffer expectedJoined = new StringBuffer();
-        final StringBuffer actualJoined = new StringBuffer();
+        final StringBuffer expectedJoined = new StringBuffer(expected.length * 19);
+        final StringBuffer actualJoined = new StringBuffer(actual.length * 19);
         for (final Object element : expected) {
             expectedJoined.append(element).append('\n');
         }

--- a/xstream/src/test/com/thoughtworks/xstream/io/binary/TokenTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/io/binary/TokenTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2006 Joe Walnes.
- * Copyright (C) 2006, 2007, 2009, 2018 XStream Committers.
+ * Copyright (C) 2006, 2007, 2009, 2018, 2020 XStream Committers.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD

--- a/xstream/src/test/com/thoughtworks/xstream/io/binary/TokenTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/io/binary/TokenTest.java
@@ -88,7 +88,7 @@ public class TokenTest extends TestCase {
     }
 
     public void testUsesIdForStringsWithMoreThen64KBytes() throws IOException {
-        final StringBuffer builder = new StringBuffer();
+        final StringBuffer builder = new StringBuffer(40000);
         for (int i = 0; i++ < 8000;) {
             builder.append("\u0391\u03b8\u03ae\u03bd\u03b1"); // Athens
         }


### PR DESCRIPTION
Under the StringBuffer / StringBuilder is a char array to store. If the internal buffer overflows (the default length is 16), it will automatically become larger. A new internal buffer will be allocated to the array copy. Although it cannot be completely avoided, it can reduce the expansion It's not bad.