### PR TITLE
Throwing UnsupportedEncodingException is meaningless

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/io/binary/Token.java
+++ b/xstream/src/java/com/thoughtworks/xstream/io/binary/Token.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2006 Joe Walnes.
- * Copyright (C) 2006, 2007, 2009, 2013, 2014 XStream Committers.
+ * Copyright (C) 2006, 2007, 2009, 2013, 2014, 2020 XStream Committers.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD

--- a/xstream/src/java/com/thoughtworks/xstream/io/binary/Token.java
+++ b/xstream/src/java/com/thoughtworks/xstream/io/binary/Token.java
@@ -14,6 +14,7 @@ package com.thoughtworks.xstream.io.binary;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import com.thoughtworks.xstream.io.StreamException;
 
@@ -134,7 +135,7 @@ public abstract class Token {
     }
 
     protected void writeString(final DataOutput out, final String string) throws IOException {
-        final byte[] bytes = string.length() > MAX_UTF8_LENGTH / 4 ? string.getBytes("utf-8") : new byte[0];
+        final byte[] bytes = string.length() > MAX_UTF8_LENGTH / 4 ? string.getBytes(StandardCharsets.UTF_8) : new byte[0];
         final int length = bytes.length;
         if (length <= MAX_UTF8_LENGTH) {
             out.writeUTF(string);
@@ -168,7 +169,7 @@ public abstract class Token {
         final int size = in.readInt();
         final byte[] bytes = new byte[size];
         in.readFully(bytes);
-        return new String(bytes, "utf-8");
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     public static class Formatter {

--- a/xstream/src/java/com/thoughtworks/xstream/io/json/JsonHierarchicalStreamDriver.java
+++ b/xstream/src/java/com/thoughtworks/xstream/io/json/JsonHierarchicalStreamDriver.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2006 Joe Walnes.
- * Copyright (C) 2006, 2007, 2008, 2011, 2014 XStream Committers.
+ * Copyright (C) 2006, 2007, 2008, 2011, 2014, 2020 XStream Committers.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD

--- a/xstream/src/java/com/thoughtworks/xstream/io/json/JsonHierarchicalStreamDriver.java
+++ b/xstream/src/java/com/thoughtworks/xstream/io/json/JsonHierarchicalStreamDriver.java
@@ -16,14 +16,13 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import com.thoughtworks.xstream.io.AbstractDriver;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
-import com.thoughtworks.xstream.io.StreamException;
 import com.thoughtworks.xstream.io.naming.NameCoder;
 
 
@@ -82,12 +81,8 @@ public class JsonHierarchicalStreamDriver extends AbstractDriver {
 
     @Override
     public HierarchicalStreamWriter createWriter(final OutputStream out) {
-        try {
-            // JSON spec requires UTF-8
-            return createWriter(new OutputStreamWriter(out, "UTF-8"));
-        } catch (final UnsupportedEncodingException e) {
-            throw new StreamException(e);
-        }
+         // JSON spec requires UTF-8
+         return createWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
     }
 
 }

--- a/xstream/src/java/com/thoughtworks/xstream/persistence/FilePersistenceStrategy.java
+++ b/xstream/src/java/com/thoughtworks/xstream/persistence/FilePersistenceStrategy.java
@@ -54,7 +54,7 @@ public class FilePersistenceStrategy<K, V> extends AbstractFilePersistenceStrate
      * @since 1.3.1
      */
     public FilePersistenceStrategy(final File baseDirectory, final XStream xstream) {
-        this(baseDirectory, xstream, "utf-8", "<>?:/\\\"|*%");
+        this(baseDirectory, xstream, "UTF-8", "<>?:/\\\"|*%");
     }
 
     /**

--- a/xstream/src/java/com/thoughtworks/xstream/persistence/FilePersistenceStrategy.java
+++ b/xstream/src/java/com/thoughtworks/xstream/persistence/FilePersistenceStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008, 2014, 2015, 2016 XStream Committers.
+ * Copyright (C) 2008, 2014, 2015, 2016, 2020 XStream Committers.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD


### PR DESCRIPTION
Hi!

I remember that XStream uses UTF-8 character set is very clear, if we use StandardCharsets.UTF_8, can reduce unnecessary java.nio.charset.Charset conversion, so there is no need to throw UnsupportedEncodingException.
And modify the default ‘’ utf-8 ’’ encoding to uppercase.

Regards,
Zezeng