### PR TITLE
Allow use of xsl on the fly (output)

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/CloseListener.java
+++ b/xstream/src/java/com/thoughtworks/xstream/CloseListener.java
@@ -1,0 +1,19 @@
+package com.thoughtworks.xstream;
+
+public class CloseListener {
+
+	Thread thread;
+
+	public CloseListener(Thread thread) {
+		this.thread = thread;
+	}
+
+	public void close() {
+		if (thread.isAlive())
+			try {
+				thread.join();
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+	}
+}

--- a/xstream/src/java/com/thoughtworks/xstream/XStream.java
+++ b/xstream/src/java/com/thoughtworks/xstream/XStream.java
@@ -71,6 +71,7 @@ import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
+import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
@@ -1932,6 +1933,7 @@ public class XStream {
     	final PipedInputStream pipedinput= new PipedInputStream(pipedoutput);
     	TransformerFactory instance= TransformerFactory.newInstance();
     	Transformer transformer= instance.newTransformer(stylesheet);
+    	transformer.setOutputProperty(OutputKeys.INDENT, "no");
     	Thread thread= new Thread(() -> {
     		try {
 				transformer.transform(new StreamSource(pipedinput), new StreamResult(out));

--- a/xstream/src/java/com/thoughtworks/xstream/XStream.java
+++ b/xstream/src/java/com/thoughtworks/xstream/XStream.java
@@ -78,7 +78,6 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
-import com.sun.media.jfxmedia.logging.Logger;
 import com.thoughtworks.xstream.converters.ConversionException;
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.ConverterLookup;

--- a/xstream/src/test/com/thoughtworks/xstream/XStreamTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/XStreamTest.java
@@ -22,6 +22,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.stream.StreamSource;
@@ -403,39 +404,39 @@ public class XStreamTest extends TestCase {
     	ByteArrayOutputStream out = new ByteArrayOutputStream();
         InputStream xslt= XStreamTest.class.getResourceAsStream("identity.xsl");
         DataHolder newDataHolder = xstream.newDataHolder();
-		final ObjectOutputStream oout = xstream.createObjectOutputStream(out,Charset.defaultCharset(),"rootname",new StreamSource(xslt),newDataHolder);
+		final ObjectOutputStream oout = xstream.createObjectOutputStream(out,StandardCharsets.UTF_8,"rootname",new StreamSource(xslt),newDataHolder);
         oout.writeObject(new Integer(1));
         oout.flush();
         oout.close();
         Assert.assertEquals(
-        		"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\r\n" + 
-        		"<rootname>\r\n" + 
-        		"  <int>1</int>\r\n" + 
-        		"</rootname>\r\n" + 
+        		"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +System.lineSeparator()+ 
+        		"<rootname>" +System.lineSeparator()+ 
+        		"  <int>1</int>" +System.lineSeparator()+ 
+        		"</rootname>" +System.lineSeparator()+ 
         		"", out.toString());
     }
     
     public void testObjectOutputStreamXSLSimpleSmokeTest2() throws IOException, TransformerConfigurationException, InterruptedException {
     	ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	StringReader strs=new StringReader("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + 
-        		"<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"1.0\">\r\n" + 
-        		"<xsl:output method=\"xml\" indent=\"yes\" standalone=\"yes\" />\r\n" + 
-        		"<xsl:template match=\"@*|node()\">\r\n" + 
-        		"   <xsl:copy>\r\n" + 
-        		"      <xsl:apply-templates select=\"@*|node()\"/>\r\n" + 
-        		"   </xsl:copy>\r\n" + 
-        		"</xsl:template>\r\n" + 
+    	StringReader strs=new StringReader("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +System.lineSeparator()+ 
+        		"<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"1.0\">" +System.lineSeparator()+ 
+        		"<xsl:output method=\"xml\" indent=\"yes\" standalone=\"yes\" />" +System.lineSeparator()+ 
+        		"<xsl:template match=\"@*|node()\">" +System.lineSeparator()+ 
+        		"   <xsl:copy>" +System.lineSeparator()+ 
+        		"      <xsl:apply-templates select=\"@*|node()\"/>" +System.lineSeparator()+ 
+        		"   </xsl:copy>" +System.lineSeparator()+ 
+        		"</xsl:template>" +System.lineSeparator()+ 
         		"</xsl:stylesheet>");
         DataHolder newDataHolder = xstream.newDataHolder();
-		final ObjectOutputStream oout = xstream.createObjectOutputStream(out,Charset.defaultCharset(),"rootname",new StreamSource(strs),newDataHolder);
+		final ObjectOutputStream oout = xstream.createObjectOutputStream(out,StandardCharsets.UTF_8,"rootname",new StreamSource(strs),newDataHolder);
         oout.writeObject(new Integer(1));
         oout.flush();
         oout.close();
         Assert.assertEquals(
-        		"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\r\n" + 
-        		"<rootname>\r\n" + 
-        		"  <int>1</int>\r\n" + 
-        		"</rootname>\r\n" + 
+        		"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +System.lineSeparator()+ 
+        		"<rootname>" +System.lineSeparator()+ 
+        		"  <int>1</int>" +System.lineSeparator()+  
+        		"</rootname>" +System.lineSeparator()+ 
         		"", out.toString());
     }
     
@@ -452,12 +453,12 @@ public class XStreamTest extends TestCase {
         		"</xsl:template>\r\n" + 
         		"</xsl:stylesheet>");
         DataHolder newDataHolder = xstream.newDataHolder();
-		final ObjectOutputStream oout = xstream.createObjectOutputStream(out,Charset.defaultCharset(),"rootname",new StreamSource(strs),newDataHolder);
+		final ObjectOutputStream oout = xstream.createObjectOutputStream(out,StandardCharsets.UTF_8,"rootname",new StreamSource(strs),newDataHolder);
         oout.writeObject(new Integer(1));
         oout.flush();
         oout.close();
         Assert.assertEquals(
-        		"found=1\r\n" + 
+        		"found=1" +System.lineSeparator()+ 
         		"", out.toString());
     }
 

--- a/xstream/src/test/com/thoughtworks/xstream/XStreamTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/XStreamTest.java
@@ -413,7 +413,7 @@ public class XStreamTest extends TestCase {
         		"<rootname>" +System.lineSeparator()+ 
         		"  <int>1</int>" +System.lineSeparator()+ 
         		"</rootname>" +System.lineSeparator()+ 
-        		"", out.toString());
+        		"", out.toString("UTF-8"));
     }
     
     public void testObjectOutputStreamXSLSimpleSmokeTest2() throws IOException, TransformerConfigurationException, InterruptedException {
@@ -437,7 +437,7 @@ public class XStreamTest extends TestCase {
         		"<rootname>" +System.lineSeparator()+ 
         		"  <int>1</int>" +System.lineSeparator()+  
         		"</rootname>" +System.lineSeparator()+ 
-        		"", out.toString());
+        		"", out.toString("UTF-8"));
     }
     
     public void testObjectOutputStreamXSLGenerateINI() throws IOException, TransformerConfigurationException, InterruptedException {

--- a/xstream/src/test/com/thoughtworks/xstream/XStreamTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/XStreamTest.java
@@ -409,11 +409,10 @@ public class XStreamTest extends TestCase {
         oout.flush();
         oout.close();
         Assert.assertEquals(
-        		"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +System.lineSeparator()+ 
+        		"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"+ 
         		"<rootname>" +System.lineSeparator()+ 
         		"  <int>1</int>" +System.lineSeparator()+ 
-        		"</rootname>" +System.lineSeparator()+ 
-        		"", out.toString("UTF-8"));
+        		"</rootname>", out.toString("UTF-8"));
     }
     
     public void testObjectOutputStreamXSLSimpleSmokeTest2() throws IOException, TransformerConfigurationException, InterruptedException {
@@ -421,11 +420,7 @@ public class XStreamTest extends TestCase {
     	StringReader strs=new StringReader("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +System.lineSeparator()+ 
         		"<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"1.0\">" +System.lineSeparator()+ 
         		"<xsl:output method=\"xml\" indent=\"yes\" standalone=\"yes\" />" +System.lineSeparator()+ 
-        		"<xsl:template match=\"@*|node()\">" +System.lineSeparator()+ 
-        		"   <xsl:copy>" +System.lineSeparator()+ 
-        		"      <xsl:apply-templates select=\"@*|node()\"/>" +System.lineSeparator()+ 
-        		"   </xsl:copy>" +System.lineSeparator()+ 
-        		"</xsl:template>" +System.lineSeparator()+ 
+        		"<xsl:template match=\"@*|node()\"><xsl:copy><xsl:apply-templates select=\"@*|node()\"/></xsl:copy></xsl:template>" +System.lineSeparator()+ 
         		"</xsl:stylesheet>");
         DataHolder newDataHolder = xstream.newDataHolder();
 		final ObjectOutputStream oout = xstream.createObjectOutputStream(out,StandardCharsets.UTF_8,"rootname",new StreamSource(strs),newDataHolder);
@@ -433,11 +428,10 @@ public class XStreamTest extends TestCase {
         oout.flush();
         oout.close();
         Assert.assertEquals(
-        		"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +System.lineSeparator()+ 
+        		"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" + 
         		"<rootname>" +System.lineSeparator()+ 
         		"  <int>1</int>" +System.lineSeparator()+  
-        		"</rootname>" +System.lineSeparator()+ 
-        		"", out.toString("UTF-8"));
+        		"</rootname>", out.toString("UTF-8"));
     }
     
     public void testObjectOutputStreamXSLGenerateINI() throws IOException, TransformerConfigurationException, InterruptedException {

--- a/xstream/src/test/com/thoughtworks/xstream/identity.xsl
+++ b/xstream/src/test/com/thoughtworks/xstream/identity.xsl
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+<xsl:output method="xml" indent="yes" standalone="yes" />
+<xsl:template match="@*|node()">
+   <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+   </xsl:copy>
+</xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Prove of concept for using xsl internally to xstream.
Same could be done for input and simplifies usage. Not sure if it would be possible to implement "streaming" (low memory footprint) in some use cases. There are some flaws regarding threading in the implementation but do not care for the moment.