### PR TITLE
CompositeClassLoader is inappropriately using reflection for methods …

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/core/util/CompositeClassLoader.java
+++ b/xstream/src/java/com/thoughtworks/xstream/core/util/CompositeClassLoader.java
@@ -53,13 +53,13 @@ public class CompositeClassLoader extends ClassLoader {
     static {
         // see http://www.cs.duke.edu/csed/java/jdk1.7/technotes/guides/lang/cl-mt.html
         try {
-            final Method m = ClassLoader.class.getDeclaredMethod("registerAsParallelCapable");
-            if (!m.isAccessible()) {
-                m.setAccessible(true);
-            }
-            m.invoke(null);
+            ClassLoader.registerAsParallelCapable();
         } catch (final Exception e) {
             // ignore errors, JVM will synchronize class for Java 7 or higher
+            //Should write that there was an issue before proceeding.
+            System.err.println("Warning: Failed to register as a Parallel ClassLoader: " + e.getMessage());
+            System.err.println("This may negatively impact performance");
+            System.err.println("Falling back to synchronized classloading");
         }
     }
 

--- a/xstream/src/test/com/thoughtworks/xstream/core/util/CompositeClassLoaderTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/core/util/CompositeClassLoaderTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020 Steve Davidson
+ * Copyright (C) 2020 XStream Committers.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ * 
+ * Created on 30. July 2020 by Steve Davidson
+ */
+
+package com.thoughtworks.xstream.core.util;
+
+import junit.framework.TestCase;
+
+public class CompositeClassLoaderTest extends TestCase {
+
+    class DummyClassLoader extends ClassLoader {
+        public DummyClassLoader(){
+            //end init
+        }
+    }
+
+    public void testAdd(){
+        //Just check that Exceptions don't get thrown
+        final CompositeClassLoader cl = new CompositeClassLoader();
+        ClassLoader testCl = new DummyClassLoader();
+        cl.add(testCl);
+        cl.add(testCl);
+        testCl = null;
+        cl.add(testCl);
+    }
+}
+


### PR DESCRIPTION
…it has access to #214

https://github.com/x-stream/xstream/issues/214
Invoked registerAsParallelCapable directly.
Add some logging if there is an error (fail silently is rarely a good thing).

Signed-off-by: Steve Davidson <steve@j2eeguys.com>