### PR TITLE
Prevent 'illegal reflective access' problems when instantiating XStream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -673,6 +673,12 @@
         <version>${version.org.ops4j.pax.exam}</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>io.github.classgraph</groupId>
+        <artifactId>classgraph</artifactId>
+        <version>${version.io.github.classgraph}</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -1095,6 +1101,7 @@
     <version.commons.codec>1.11</version.commons.codec>
     <version.commons.lang3>3.8.1</version.commons.lang3>
     <version.hsqldb>2.2.8</version.hsqldb>
+    <version.io.github.classgraph>4.8.87</version.io.github.classgraph>
     <version.jakarta.activation.api>1.2.1</version.jakarta.activation.api>
     <version.jakarta.annotation.api>1.3.4</version.jakarta.annotation.api>
     <version.jakarta.xml.bind.api>2.3.2</version.jakarta.xml.bind.api>

--- a/xstream/pom.xml
+++ b/xstream/pom.xml
@@ -137,6 +137,11 @@
       <artifactId>commons-lang3</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.github.classgraph</groupId>
+      <artifactId>classgraph</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/xstream/src/java/com/thoughtworks/xstream/converters/collections/PropertiesConverter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/collections/PropertiesConverter.java
@@ -6,7 +6,7 @@
  * The software in this package is published under the terms of the BSD
  * style license a copy of which has been included with this distribution in
  * the LICENSE.txt file.
- * 
+ *
  * Created on 23. February 2004 by Joe Walnes
  */
 package com.thoughtworks.xstream.converters.collections;
@@ -35,13 +35,12 @@ import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
  * permissions for SecurityManager.checkPackageAccess, SecurityManager.checkMemberAccess(this, EnumSet.MEMBER) and
  * ReflectPermission("suppressAccessChecks").
  * </p>
- * 
+ *
  * @author Joe Walnes
  * @author Kevin Ring
  */
 public class PropertiesConverter implements Converter {
 
-    private final static Field defaultsField = Fields.locate(Properties.class, Properties.class, false);
     private final boolean sort;
 
     public PropertiesConverter() {
@@ -67,8 +66,8 @@ public class PropertiesConverter implements Converter {
             writer.addAttribute("value", entry.getValue().toString());
             writer.endNode();
         }
-        if (defaultsField != null) {
-            final Properties defaults = (Properties)Fields.read(defaultsField, properties);
+        if (Reflections.defaultsField != null) {
+            final Properties defaults = (Properties)Fields.read(Reflections.defaultsField, properties);
             if (defaults != null) {
                 writer.startNode("defaults");
                 marshal(defaults, writer, context);
@@ -101,4 +100,7 @@ public class PropertiesConverter implements Converter {
         }
     }
 
+    private static class Reflections {
+        private final static Field defaultsField = Fields.locate(Properties.class, Properties.class, false);
+    }
 }

--- a/xstream/src/java/com/thoughtworks/xstream/converters/enums/EnumMapConverter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/enums/EnumMapConverter.java
@@ -6,7 +6,7 @@
  * The software in this package is published under the terms of the BSD
  * style license a copy of which has been included with this distribution in
  * the LICENSE.txt file.
- * 
+ *
  * Created on 06. April 2005 by Joe Walnes
  */
 
@@ -31,12 +31,11 @@ import com.thoughtworks.xstream.mapper.Mapper;
  * If a {@link SecurityManager} is set, the converter will only work with permissions for SecurityManager.checkPackageAccess,
  * SecurityManager.checkMemberAccess(this, EnumSet.MEMBER) and ReflectPermission("suppressAccessChecks").
  * </p>
- * 
+ *
  * @author Joe Walnes
  */
 public class EnumMapConverter extends MapConverter {
 
-    private final static Field typeField = Fields.locate(EnumMap.class, Class.class, false);
 
     public EnumMapConverter(final Mapper mapper) {
         super(mapper);
@@ -44,12 +43,12 @@ public class EnumMapConverter extends MapConverter {
 
     @Override
     public boolean canConvert(final Class<?> type) {
-        return typeField != null && type == EnumMap.class;
+        return type == EnumMap.class && Reflections.typeField != null;
     }
 
     @Override
     public void marshal(final Object source, final HierarchicalStreamWriter writer, final MarshallingContext context) {
-        final Class<?> type = (Class<?>)Fields.read(typeField, source);
+        final Class<?> type = (Class<?>)Fields.read(Reflections.typeField, source);
         final String attributeName = mapper().aliasForSystemAttribute("enum-type");
         if (attributeName != null) {
             writer.addAttribute(attributeName, mapper().serializedClass(type));
@@ -68,5 +67,9 @@ public class EnumMapConverter extends MapConverter {
         final EnumMap<?, ?> map = new EnumMap(type);
         populateMap(reader, context, map);
         return map;
+    }
+
+    private static class Reflections {
+        private final static Field typeField = Fields.locate(EnumMap.class, Class.class, false);
     }
 }

--- a/xstream/src/java/com/thoughtworks/xstream/converters/enums/EnumSetConverter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/enums/EnumSetConverter.java
@@ -6,7 +6,7 @@
  * The software in this package is published under the terms of the BSD
  * style license a copy of which has been included with this distribution in
  * the LICENSE.txt file.
- * 
+ *
  * Created on 06. April 2005 by Joe Walnes
  */
 
@@ -31,13 +31,12 @@ import com.thoughtworks.xstream.mapper.Mapper;
  * If a SecurityManager is set, the converter will only work with permissions for SecurityManager.checkPackageAccess,
  * SecurityManager.checkMemberAccess(this, EnumSet.MEMBER) and ReflectPermission("suppressAccessChecks").
  * </p>
- * 
+ *
  * @author Joe Walnes
  * @author J&ouml;rg Schaible
  */
 public class EnumSetConverter implements Converter {
 
-    private final static Field typeField = Fields.locate(EnumSet.class, Class.class, false);
     private final Mapper mapper;
 
     public EnumSetConverter(final Mapper mapper) {
@@ -46,13 +45,13 @@ public class EnumSetConverter implements Converter {
 
     @Override
     public boolean canConvert(final Class<?> type) {
-        return typeField != null && type != null && EnumSet.class.isAssignableFrom(type);
+        return type != null && EnumSet.class.isAssignableFrom(type) && Reflections.typeField != null;
     }
 
     @Override
     public void marshal(final Object source, final HierarchicalStreamWriter writer, final MarshallingContext context) {
         final EnumSet<?> set = (EnumSet<?>)source;
-        final Class<?> enumTypeForSet = (Class<?>)Fields.read(typeField, set);
+        final Class<?> enumTypeForSet = (Class<?>)Fields.read(Reflections.typeField, set);
         final String attributeName = mapper.aliasForSystemAttribute("enum-type");
         if (attributeName != null) {
             writer.addAttribute(attributeName, mapper.serializedClass(enumTypeForSet));
@@ -99,4 +98,7 @@ public class EnumSetConverter implements Converter {
         return set;
     }
 
+    private static class Reflections {
+        private final static Field typeField = Fields.locate(EnumSet.class, Class.class, false);
+    }
 }

--- a/xstream/src/java/com/thoughtworks/xstream/converters/extended/DynamicProxyConverter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/extended/DynamicProxyConverter.java
@@ -6,7 +6,7 @@
  * The software in this package is published under the terms of the BSD
  * style license a copy of which has been included with this distribution in
  * the LICENSE.txt file.
- * 
+ *
  * Created on 25. March 2004 by Joe Walnes
  */
 package com.thoughtworks.xstream.converters.extended;
@@ -32,20 +32,13 @@ import com.thoughtworks.xstream.mapper.Mapper;
 
 /**
  * Converts a dynamic proxy to XML, storing the implemented interfaces and handler.
- * 
+ *
  * @author Joe Walnes
  */
 public class DynamicProxyConverter implements Converter {
 
     private final ClassLoaderReference classLoaderReference;
     private final Mapper mapper;
-    private static final Field HANDLER = Fields.locate(Proxy.class, InvocationHandler.class, false);
-    private static final InvocationHandler DUMMY = new InvocationHandler() {
-        @Override
-        public Object invoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
-            return null;
-        }
-    };
 
     /**
      * @deprecated As of 1.4.5 use {@link #DynamicProxyConverter(Mapper, ClassLoaderReference)}
@@ -57,7 +50,7 @@ public class DynamicProxyConverter implements Converter {
 
     /**
      * Construct a DynamicProxyConverter.
-     * 
+     *
      * @param mapper the Mapper chain
      * @param classLoaderReference the reference to the {@link ClassLoader} of the XStream instance
      * @since 1.4.5
@@ -127,16 +120,27 @@ public class DynamicProxyConverter implements Converter {
         final Class<?>[] interfacesAsArray = new Class[interfaces.size()];
         interfaces.toArray(interfacesAsArray);
         Object proxy = null;
-        if (HANDLER != null) { // we will not be able to resolve references to the proxy
-            proxy = Proxy.newProxyInstance(classLoaderReference.getReference(), interfacesAsArray, DUMMY);
+        if (Reflections.HANDLER != null) { // we will not be able to resolve references to the proxy
+            proxy = Proxy.newProxyInstance(classLoaderReference.getReference(), interfacesAsArray, Reflections.DUMMY);
         }
         handler = (InvocationHandler)context.convertAnother(proxy, handlerType);
         reader.moveUp();
-        if (HANDLER != null) {
-            Fields.write(HANDLER, proxy, handler);
+        if (Reflections.HANDLER != null) {
+            Fields.write(Reflections.HANDLER, proxy, handler);
         } else {
             proxy = Proxy.newProxyInstance(classLoaderReference.getReference(), interfacesAsArray, handler);
         }
         return proxy;
+    }
+
+    private static class Reflections {
+
+        private static final Field HANDLER = Fields.locate(Proxy.class, InvocationHandler.class, false);
+        private static final InvocationHandler DUMMY = new InvocationHandler() {
+            @Override
+            public Object invoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
+                return null;
+            }
+        };
     }
 }

--- a/xstream/src/java/com/thoughtworks/xstream/converters/reflection/AbstractAttributedCharacterIteratorAttributeConverter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/reflection/AbstractAttributedCharacterIteratorAttributeConverter.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Modifier;
 import java.text.AttributedCharacterIterator;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.thoughtworks.xstream.converters.ConversionException;
 import com.thoughtworks.xstream.converters.basic.AbstractSingleValueConverter;
@@ -34,26 +35,9 @@ public class AbstractAttributedCharacterIteratorAttributeConverter<T extends Att
     extends AbstractSingleValueConverter {
 
     private static final Map<String, Map<String, ? extends AttributedCharacterIterator.Attribute>> instanceMaps =
-            new HashMap<>();
-    private static final Method getName;
-
-    static {
-        Method method = null;
-        try {
-            method = AttributedCharacterIterator.Attribute.class.getDeclaredMethod("getName", (Class[])null);
-            if (!method.isAccessible()) {
-                method.setAccessible(true);
-            }
-        } catch (final SecurityException e) {
-            // ignore for now
-        } catch (final NoSuchMethodException e) {
-            // ignore for now
-        }
-        getName = method;
-    }
+            new ConcurrentHashMap<>();
 
     private final Class<? extends T> type;
-    private transient Map<String, T> attributeMap;
 
     public AbstractAttributedCharacterIteratorAttributeConverter(final Class<? extends T> type) {
         super();
@@ -63,12 +47,11 @@ public class AbstractAttributedCharacterIteratorAttributeConverter<T extends Att
                 + AttributedCharacterIterator.Attribute.class.getName());
         }
         this.type = type;
-        readResolve();
     }
 
     @Override
     public boolean canConvert(final Class<?> type) {
-        return type == this.type && !attributeMap.isEmpty();
+        return type == this.type && !getAttributeMap().isEmpty();
     }
 
     @Override
@@ -80,9 +63,9 @@ public class AbstractAttributedCharacterIteratorAttributeConverter<T extends Att
 
     private String getName(final AttributedCharacterIterator.Attribute attribute) {
         Exception ex = null;
-        if (getName != null) {
+        if (Reflections.getName != null) {
             try {
-                return (String)getName.invoke(attribute);
+                return (String)Reflections.getName.invoke(attribute);
             } catch (final IllegalAccessException e) {
                 ex = e;
             } catch (final InvocationTargetException e) {
@@ -101,8 +84,9 @@ public class AbstractAttributedCharacterIteratorAttributeConverter<T extends Att
 
     @Override
     public Object fromString(final String str) {
-        if (attributeMap.containsKey(str)) {
-            return attributeMap.get(str);
+        T attr = getAttributeMap().get(str);
+        if (attr != null) {
+            return attr;
         }
         final ConversionException exception = new ConversionException("Cannot find attribute");
         exception.add("attribute-type", type.getName());
@@ -110,50 +94,69 @@ public class AbstractAttributedCharacterIteratorAttributeConverter<T extends Att
         throw exception;
     }
 
-    private Object readResolve() {
+    private Map<String, T> getAttributeMap() {
         @SuppressWarnings("unchecked")
-        final Map<String, T> typedMap = (Map<String, T>)instanceMaps.get(type.getName());
-        attributeMap = typedMap;
-        if (attributeMap == null) {
-            attributeMap = new HashMap<>();
-            final Field instanceMap = Fields.locate(type, Map.class, true);
-            if (instanceMap != null) {
-                try {
-                    @SuppressWarnings("unchecked")
-                    final Map<String, T> map = (Map<String, T>)Fields.read(instanceMap, null);
-                    if (map != null) {
-                        boolean valid = true;
-                        for (final Map.Entry<String, T> entry : map.entrySet()) {
-                            valid = entry.getKey().getClass() == String.class && entry.getValue().getClass() == type;
-                        }
-                        if (valid) {
-                            attributeMap.putAll(map);
-                        }
-                    }
-                } catch (final ObjectAccessException e) {
-                }
-            }
-            if (attributeMap.isEmpty()) {
-                try {
-                    final Field[] fields = type.getDeclaredFields();
-                    for (final Field field : fields) {
-                        if (field.getType() == type == Modifier.isStatic(field.getModifiers())) {
-                            @SuppressWarnings("unchecked")
-                            final T attribute = (T)Fields.read(field, null);
-                            attributeMap.put(toString(attribute), attribute);
-                        }
-                    }
-                } catch (final SecurityException e) {
-                    attributeMap.clear();
-                } catch (final ObjectAccessException e) {
-                    attributeMap.clear();
-                } catch (final NoClassDefFoundError e) {
-                    attributeMap.clear();
-                }
-            }
-            instanceMaps.put(type.getName(), attributeMap);
-        }
-        return this;
+        final Map<String, T> map = (Map<String, T>) instanceMaps.computeIfAbsent(type.getName(), t -> buildAttributeMap(type));
+        return map;
     }
 
+    private Map<String, T> buildAttributeMap(Class<? extends T> type) {
+        final Map<String, T> attributeMap = new HashMap<>();
+        final Field instanceMap = Fields.locate(type, Map.class, true);
+        if (instanceMap != null) {
+            try {
+                @SuppressWarnings("unchecked")
+                final Map<String, T> map = (Map<String, T>)Fields.read(instanceMap, null);
+                if (map != null) {
+                    boolean valid = true;
+                    for (final Map.Entry<String, T> entry : map.entrySet()) {
+                        valid = entry.getKey().getClass() == String.class && entry.getValue().getClass() == type;
+                    }
+                    if (valid) {
+                        attributeMap.putAll(map);
+                    }
+                }
+            } catch (final ObjectAccessException e) {
+            }
+        }
+        if (attributeMap.isEmpty()) {
+            try {
+                final Field[] fields = type.getDeclaredFields();
+                for (final Field field : fields) {
+                    if (field.getType() == type == Modifier.isStatic(field.getModifiers())) {
+                        @SuppressWarnings("unchecked")
+                        final T attribute = (T)Fields.read(field, null);
+                        attributeMap.put(toString(attribute), attribute);
+                    }
+                }
+            } catch (final SecurityException e) {
+                attributeMap.clear();
+            } catch (final ObjectAccessException e) {
+                attributeMap.clear();
+            } catch (final NoClassDefFoundError e) {
+                attributeMap.clear();
+            }
+        }
+        return attributeMap;
+    }
+
+    private static class Reflections {
+
+        private static final Method getName;
+
+        static {
+            Method method = null;
+            try {
+                method = AttributedCharacterIterator.Attribute.class.getDeclaredMethod("getName", (Class[])null);
+                if (!method.isAccessible()) {
+                    method.setAccessible(true);
+                }
+            } catch (final SecurityException e) {
+                // ignore for now
+            } catch (final NoSuchMethodException e) {
+                // ignore for now
+            }
+            getName = method;
+        }
+    }
 }

--- a/xstream/src/test/com/thoughtworks/xstream/converters/ConvertersArchTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/converters/ConvertersArchTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2006, 2007, 2016 XStream Committers.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ * Created on 29. July 2020 by Falko Modler
+ */
+package com.thoughtworks.xstream.converters;
+
+import java.util.stream.Collectors;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ScanResult;
+import io.github.classgraph.FieldInfoList.FieldInfoFilter;
+import junit.framework.Assert;
+import junit.framework.TestCase;
+
+/**
+ * @author Falko Modler
+ */
+public class ConvertersArchTest extends TestCase {
+
+    private static final FieldInfoFilter REFLECTION_FIELD =
+            fieldInfo -> fieldInfo.isStatic() && fieldInfo.getTypeDescriptor().toString().startsWith("java.lang.reflect.");
+
+    /**
+     * Tests that no converter has a static field of type {@code java.lang.reflect.*} which hints at eager reflection access at construction time.
+     * Such eager access will cause unecessary "illegal reflective access" warnings or even failures when {@code XStream} is just instantiated (not even executed).
+     */
+    public void testNoEagerStaticReflectionFields() {
+        String violatingFields = "";
+
+        try(ScanResult scanResult = new ClassGraph()
+                .acceptPackages(ConvertersArchTest.class.getPackage().getName())
+                .enableFieldInfo()
+                .ignoreFieldVisibility()
+                .disableJarScanning()
+                .scan()) {
+
+            violatingFields = scanResult.getAllStandardClasses().stream()
+                    .flatMap(info -> info.getDeclaredFieldInfo().filter(REFLECTION_FIELD).stream())
+                    .map(info -> info.getClassInfo().getName() + "." + info.getName())
+                    .collect(Collectors.joining("\n\t"));
+        }
+
+        if (!violatingFields.isEmpty()) {
+            Assert.fail("The following direct java.lang.reflect fields must be moved to static inner classes "
+                    + " to avoid eager init:\n\t" + violatingFields);
+        }
+    }
+}


### PR DESCRIPTION
Relates to #101 and https://github.com/quarkusio/quarkus/issues/10303#issuecomment-665308371

I realized that just by instantiating `XStream` a whole bunch of reflection access is performed by various converters (triggered via `Xstream.setupConverters()`).
**This is regardless of whether you will actually need the converter or not, just the setup triggers this.**

This PRs defers all the static reflection access by moving the respective fields and lookups to static inner classes which per JLS are loaded on demand in a thread safe way.
I also addded a test that analyzes the classes (via https://github.com/classgraph/). First I wanted to use ArchUnit but that requires at least JUnit 4 but Core still uses 3.8.1.

The most debatable change is the one to `AbstractAttributedCharacterIteratorAttributeConverter`.
I had to drop `readResolve` method and the `attributeMap` member. The map was `transient` anyway and `readResolve` puzzled me a bit, because the converter does not seem to implement `Serializable` at all.

With this PR I am not getting any `illegal reflective access` warnings anymore when instantiating `XStream` on AdoptOpenJDK 11.0.6.