### PR TITLE
Reduce chance of CME in CollectionConverter

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/converters/collections/CollectionConverter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/collections/CollectionConverter.java
@@ -73,7 +73,7 @@ public class CollectionConverter extends AbstractCollectionConverter {
 
     @Override
     public void marshal(final Object source, final HierarchicalStreamWriter writer, final MarshallingContext context) {
-        final Collection<?> collection = (Collection<?>)source;
+        final Collection<?> collection = new ArrayList((Collection<?>)source);
         for (final Object item : collection) {
             writeCompleteItem(item, context, writer);
         }


### PR DESCRIPTION
Porting https://github.com/jenkinsci/xstream-fork/pull/1.
Should reduce the chance of

```
java.util.ConcurrentModificationException
	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:909)
	at java.util.ArrayList$Itr.next(ArrayList.java:859)
	at com.thoughtworks.xstream.converters.collections.CollectionConverter.marshal(CollectionConverter.java:73)
```

by limiting the window of time during which the collection is iterated, though does not prevent the possibility.
