### PR TITLE
Handle IllegalArgumentException

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/mapper/DefaultMapper.java
+++ b/xstream/src/java/com/thoughtworks/xstream/mapper/DefaultMapper.java
@@ -79,7 +79,7 @@ public class DefaultMapper implements Mapper {
                 initialize = elementName.charAt(0) == '[';
             }
             return Class.forName(elementName, initialize, classLoader);
-        } catch (final ClassNotFoundException e) {
+        } catch (final ClassNotFoundException | IllegalArgumentException e) {
             throw new CannotResolveClassException(elementName);
         }
     }


### PR DESCRIPTION
In cases when "name" contains colon (tag with namespace like "<v8:type>") default mapper (and ReflectionConverter) can't instantiate class via Class.forName (cause of IAE instead of CNFE) and can't skip it at all (e.g. via ignoreUnkownElements)
