### PR TITLE
make build reproducible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -783,9 +783,6 @@
                 <Automatic-Module-Name>${jar.module.name}</Automatic-Module-Name>
                 <X-Compile-Source>${version.java.source}</X-Compile-Source>
                 <X-Compile-Target>${version.java.target}</X-Compile-Target>
-                <X-Builder>Maven ${maven.version}</X-Builder>
-                <X-Build-Time>${maven.build.timestamp}</X-Build-Time>
-                <X-Build-Os>${os.name}</X-Build-Os>
               </manifestEntries>
             </archive>
           </configuration>
@@ -878,9 +875,6 @@
                 <Eclipse-SourceBundle>${project.artifactId};version=${project.info.osgiVersion}</Eclipse-SourceBundle>
                 <X-Compile-Source>${version.java.source}</X-Compile-Source>
                 <X-Compile-Target>${version.java.target}</X-Compile-Target>
-                <X-Builder>Maven ${maven.version}</X-Builder>
-                <X-Build-Time>${maven.build.timestamp}</X-Build-Time>
-                <X-Build-Os>${os.name}</X-Build-Os>
               </manifestEntries>
             </archive>
           </configuration>
@@ -948,6 +942,8 @@
             <instructions>
               <_noee>true</_noee>
               <_nouses>true</_nouses>
+              <_removeheaders>Bnd-LastModified,Built-By</_removeheaders>
+              <_reproducible>true</_reproducible>
               <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
               <Bundle-License>BSD-3-Clause</Bundle-License>
               <Specification-Version>${project.info.majorVersion}.${project.info.minorVersion}</Specification-Version><!-- FELIX-3392 -->
@@ -1086,7 +1082,7 @@
     <version.plugin.codehaus.xsite>1.3</version.plugin.codehaus.xsite>
     <version.plugin.felix.bundle>3.5.1</version.plugin.felix.bundle>
     <version.plugin.maven.antrun>1.8</version.plugin.maven.antrun>
-    <version.plugin.maven.assembly>3.1.1</version.plugin.maven.assembly>
+    <version.plugin.maven.assembly>3.2.0</version.plugin.maven.assembly>
     <version.plugin.maven.clean>3.1.0</version.plugin.maven.clean>
     <version.plugin.maven.compiler>3.8.1</version.plugin.maven.compiler>
     <version.plugin.maven.dependency>3.1.1</version.plugin.maven.dependency>
@@ -1095,13 +1091,13 @@
     <version.plugin.maven.failsafe>${version.plugin.maven.surefire}</version.plugin.maven.failsafe>
     <version.plugin.maven.gpg>3.0.1</version.plugin.maven.gpg>
     <version.plugin.maven.install>3.0.0-M1</version.plugin.maven.install>
-    <version.plugin.maven.jar>3.1.1</version.plugin.maven.jar>
+    <version.plugin.maven.jar>3.2.0</version.plugin.maven.jar>
     <version.plugin.maven.javadoc>3.2.0</version.plugin.maven.javadoc>
     <version.plugin.maven.jxr>3.0.0</version.plugin.maven.jxr>
-    <version.plugin.maven.release>2.5.3</version.plugin.maven.release>
+    <version.plugin.maven.release>3.0.0-M4</version.plugin.maven.release>
     <version.plugin.maven.resources>3.1.0</version.plugin.maven.resources>
     <version.plugin.maven.site>3.7.1</version.plugin.maven.site>
-    <version.plugin.maven.source>3.0.1</version.plugin.maven.source>
+    <version.plugin.maven.source>3.2.0</version.plugin.maven.source>
     <version.plugin.maven.surefire>3.0.0-M3</version.plugin.maven.surefire>
     <version.plugin.mojo.build-helper>3.0.0</version.plugin.mojo.build-helper>
     <version.plugin.mojo.flatten>1.1.0</version.plugin.mojo.flatten>
@@ -1154,5 +1150,7 @@
     <argLine>${surefire.argline}</argLine>
     <javadoc.doclint>-missing</javadoc.doclint>
     <surefire.argline/>
+
+    <project.build.outputTimestamp>1</project.build.outputTimestamp>
   </properties>
 </project>


### PR DESCRIPTION
see https://maven.apache.org/guides/mini/guide-reproducible-builds.html

with this update, main artifacts are reproducible
xstream-jmh-1.5.0-SNAPSHOT.jar, xstream-jmh-1.5.0-SNAPSHOT-app.zip and xstream-distribution-1.5.0-SNAPSHOT-bin.zip are not yet because of non-reproducible  `META-INF/BenchmarkList` content: I did not really dig if this file can be made reproducible