### PR TITLE
Close HierarchicalStreamReader created in XStream.fromXML(URL)

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/XStream.java
+++ b/xstream/src/java/com/thoughtworks/xstream/XStream.java
@@ -1347,7 +1347,12 @@ public class XStream {
      * @since 1.4
      */
     public Object fromXML(URL url, Object root) {
-        return unmarshal(hierarchicalStreamDriver.createReader(url), root);
+        HierarchicalStreamReader reader = hierarchicalStreamDriver.createReader(url);
+        try {
+            return unmarshal(reader, root);
+        } finally {
+            reader.close();
+        }
     }
 
     /**


### PR DESCRIPTION
If the reader is not closed when using a file URL, it is no longer possible to immediately delete the file on Windows because an IOException is thrown because it is still in use.
This is already [fixed](https://github.com/x-stream/xstream/blob/eb21c8d3b0c98e7312b65cb53cecbb4c54f6c9ee/xstream/src/java/com/thoughtworks/xstream/XStream.java#L1283-L1287) in 1.5.0-SNAPSHOT.