### PR TITLE
More defensive static init for JVM class

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/core/JVM.java
+++ b/xstream/src/java/com/thoughtworks/xstream/core/JVM.java
@@ -168,14 +168,14 @@ public class JVM implements Caching {
         try {
             new SimpleDateFormat("z").parse("UTC");
             test = true;
-        } catch (final ParseException e) {
+        } catch (final ParseException | RuntimeException e) {
             test = false;
         }
         canParseUTCDateFormat = test;
         try {
             new SimpleDateFormat("X").parse("Z");
             test = true;
-        } catch (final ParseException | IllegalArgumentException e) {
+        } catch (final ParseException | RuntimeException e) {
             test = false;
         }
         canParseISO8601TimeZoneInDateFormat = test;


### PR DESCRIPTION
On some Java 17 variants the DateFormat parse throws a NPE.
This makes xstream unusable because the JVM class does not exist.
Moreover to be more fail safe in a static class init block is always a plus.
Closes #288.