### PR TITLE
Sonarqube Fixes

### DIFF
--- a/xstream-benchmark/src/java/com/thoughtworks/xstream/tools/benchmark/model/Five.java
+++ b/xstream-benchmark/src/java/com/thoughtworks/xstream/tools/benchmark/model/Five.java
@@ -23,9 +23,9 @@ public class Five extends One {
     private int two;
     private boolean three;
     private char four;
-    private StringBuffer five;
+    private CharSequence five;
 
-    public Five(String one, int two, boolean three, char four, StringBuffer five) {
+    public Five(String one, int two, boolean three, char four, CharSequence five) {
         super(one);
         this.two = two;
         this.three = three;

--- a/xstream-benchmark/src/java/com/thoughtworks/xstream/tools/benchmark/model/FiveBean.java
+++ b/xstream-benchmark/src/java/com/thoughtworks/xstream/tools/benchmark/model/FiveBean.java
@@ -23,7 +23,7 @@ public class FiveBean extends OneBean {
     private int two;
     private boolean three;
     private char four;
-    private StringBuffer five;
+    private CharSequence five;
 
     public int getTwo() {
         return this.two;
@@ -49,11 +49,11 @@ public class FiveBean extends OneBean {
         this.four = four;
     }
 
-    public StringBuffer getFive() {
+    public CharSequence getFive() {
         return this.five;
     }
 
-    public void setFive(StringBuffer five) {
+    public void setFive(CharSequence five) {
         this.five = five;
     }
 

--- a/xstream-benchmark/src/java/com/thoughtworks/xstream/tools/benchmark/model/SerializableFive.java
+++ b/xstream-benchmark/src/java/com/thoughtworks/xstream/tools/benchmark/model/SerializableFive.java
@@ -27,9 +27,9 @@ public class SerializableFive extends SerializableOne {
     private int two;
     private boolean three;
     private char four;
-    private StringBuffer five;
+    private CharSequence five;
 
-    public SerializableFive(String one, int two, boolean three, char four, StringBuffer five) {
+    public SerializableFive(String one, int two, boolean three, char four, CharSequence five) {
         super(one);
         this.two = two;
         this.three = three;

--- a/xstream-benchmark/src/java/com/thoughtworks/xstream/tools/benchmark/reporters/HtmlReporter.java
+++ b/xstream-benchmark/src/java/com/thoughtworks/xstream/tools/benchmark/reporters/HtmlReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006 Joe Walnes.
+ * Copyright (C) 2006, 2022 Joe Walnes.
  * Copyright (C) 2006, 2007, 2015 XStream Committers.
  * All rights reserved.
  *
@@ -57,7 +57,7 @@ public class HtmlReporter implements Reporter {
     }
 
     private String css() {
-        StringBuffer css = new StringBuffer("\n");
+        StringBuilder css = new StringBuilder("\n");
         css.append("body, h1, h2, h3, td { font-family: arial; }\n");
         css.append("h1 { text-align: center; }\n");
         css.append("table, h3 { margin-left: 40px; }\n");

--- a/xstream-benchmark/src/java/com/thoughtworks/xstream/tools/benchmark/reporters/TextReporter.java
+++ b/xstream-benchmark/src/java/com/thoughtworks/xstream/tools/benchmark/reporters/TextReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006 Joe Walnes.
+ * Copyright (C) 2006, 2022 Joe Walnes.
  * Copyright (C) 2006, 2007, 2015 XStream Committers.
  * All rights reserved.
  *
@@ -83,7 +83,7 @@ public class TextReporter implements Reporter {
     }
 
     private String pad(String value) {
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         result.append(value);
         while (result.length() < 50) {
             result.append('.');

--- a/xstream-benchmark/src/java/com/thoughtworks/xstream/tools/benchmark/targets/JavaBeanTarget.java
+++ b/xstream-benchmark/src/java/com/thoughtworks/xstream/tools/benchmark/targets/JavaBeanTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, 2011, 2015 XStream Committers.
+ * Copyright (C) 2009, 2011, 2015, 2022 XStream Committers.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -41,7 +41,7 @@ public class JavaBeanTarget implements Target {
         five.setTwo(2);
         five.setThree(true);
         five.setFour('4');
-        five.setFive(new StringBuffer("5"));
+        five.setFive(new StringBuilder("5"));
         list.add(five);
     }
     

--- a/xstream/src/java/com/thoughtworks/xstream/core/util/FastStack.java
+++ b/xstream/src/java/com/thoughtworks/xstream/core/util/FastStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004, 2005 Joe Walnes.
+ * Copyright (C) 2004, 2005, 2022 Joe Walnes.
  * Copyright (C) 2006, 2007, 2009, 2014, 2018 XStream Committers.
  * All rights reserved.
  *
@@ -87,7 +87,7 @@ public final class FastStack<T> {
 
     @Override
     public String toString() {
-        final StringBuffer result = new StringBuffer("[");
+        final StringBuilder result = new StringBuilder("[");
         for (int i = 0; i < pointer; i++) {
             if (i > 0) {
                 result.append(", ");

--- a/xstream/src/java/com/thoughtworks/xstream/core/util/XmlHeaderAwareReader.java
+++ b/xstream/src/java/com/thoughtworks/xstream/core/util/XmlHeaderAwareReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007, 2008, 2010, 2014, 2015, 2020 XStream Committers.
+ * Copyright (C) 2007, 2008, 2010, 2014, 2015, 2020, 2022 XStream Committers.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -74,8 +74,8 @@ public final class XmlHeaderAwareReader extends Reader {
         int i = 0;
         char ch = 0;
         char valueEnd = 0;
-        final StringBuffer name = new StringBuffer();
-        final StringBuffer value = new StringBuffer();
+        final StringBuilder name = new StringBuilder();
+        final StringBuilder value = new StringBuilder();
         boolean escape = false;
         while (i != -1 && (i = in[0].read()) != -1) {
             out.write(i);

--- a/xstream/src/java/com/thoughtworks/xstream/io/path/PathTracker.java
+++ b/xstream/src/java/com/thoughtworks/xstream/io/path/PathTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004, 2005, 2006 Joe Walnes.
+ * Copyright (C) 2004, 2005, 2006, 2022 Joe Walnes.
  * Copyright (C) 2006, 2007, 2009, 2011, 2014, 2015, 2020 XStream Committers.
  * All rights reserved.
  *
@@ -130,7 +130,7 @@ public class PathTracker {
         final Integer integer = indexMapStack[idx].get(pathStack[idx]);
         final int index = integer.intValue();
         if (index > 1) {
-            final StringBuffer chunk = new StringBuffer(pathStack[idx].length() + 6);
+            final StringBuilder chunk = new StringBuilder(pathStack[idx].length() + 6);
             chunk.append(pathStack[idx]).append('[').append(index).append(']');
             name = chunk.toString();
         } else {

--- a/xstream/src/java/com/thoughtworks/xstream/io/xml/AbstractPullReader.java
+++ b/xstream/src/java/com/thoughtworks/xstream/io/xml/AbstractPullReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2006 Joe Walnes.
+ * Copyright (C) 2005, 2006, 2022 Joe Walnes.
  * Copyright (C) 2006, 2007, 2009, 2010, 2011, 2014, 2015, 2016 XStream Committers.
  * All rights reserved.
  *
@@ -183,7 +183,7 @@ public abstract class AbstractPullReader extends AbstractXmlReader {
         // lets only use a string buffer when we get 2 strings
         // to avoid copying strings
         String last = null;
-        StringBuffer buffer = null;
+        StringBuilder buffer = null;
 
         mark();
         Event event = readEvent();
@@ -195,7 +195,7 @@ public abstract class AbstractPullReader extends AbstractXmlReader {
                         last = text;
                     } else {
                         if (buffer == null) {
-                            buffer = new StringBuffer(last);
+                            buffer = new StringBuilder(last);
                         }
                         buffer.append(text);
                     }

--- a/xstream/src/java/com/thoughtworks/xstream/io/xml/DomDriver.java
+++ b/xstream/src/java/com/thoughtworks/xstream/io/xml/DomDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004, 2005, 2006 Joe Walnes.
+ * Copyright (C) 2004, 2005, 2006, 2022 Joe Walnes.
  * Copyright (C) 2006, 2007, 2008, 2009, 2011, 2014, 2015, 2020 XStream Committers.
  * All rights reserved.
  *
@@ -20,6 +20,7 @@ import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.net.URL;
+import javax.xml.XMLConstants;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -102,6 +103,9 @@ public class DomDriver extends AbstractXmlDriver {
                     }
                 }
             }
+            //https://rules.sonarsource.com/java/RSPEC-2755
+            documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
             final DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
             if (encoding != null) {
                 source.setEncoding(encoding);

--- a/xstream/src/java/com/thoughtworks/xstream/io/xml/XmlFriendlyNameCoder.java
+++ b/xstream/src/java/com/thoughtworks/xstream/io/xml/XmlFriendlyNameCoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006 Joe Walnes.
+ * Copyright (C) 2006, 2022 Joe Walnes.
  * Copyright (C) 2006, 2007, 2008, 2009, 2011, 2013, 2014, 2015, 2019, 2020, 2021 XStream Committers.
  * All rights reserved.
  *
@@ -497,7 +497,7 @@ public class XmlFriendlyNameCoder implements NameCoder, Cloneable {
             }
 
             // Otherwise full processing
-            final StringBuffer result = new StringBuffer(length + 8);
+            final StringBuilder result = new StringBuilder(length + 8);
 
             // We know first N chars are safe
             if (i > 0) {
@@ -555,7 +555,7 @@ public class XmlFriendlyNameCoder implements NameCoder, Cloneable {
             }
 
             // Otherwise full processing
-            final StringBuffer result = new StringBuffer(length + 8);
+            final StringBuilder result = new StringBuilder(length + 8);
 
             // We know first N chars are safe
             if (i > 0) {

--- a/xstream/src/java/com/thoughtworks/xstream/io/xml/XomReader.java
+++ b/xstream/src/java/com/thoughtworks/xstream/io/xml/XomReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004, 2005, 2006 Joe Walnes.
+ * Copyright (C) 2004, 2005, 2006, 2022 Joe Walnes.
  * Copyright (C) 2006, 2007, 2009, 2011, 2014 XStream Committers.
  * All rights reserved.
  *
@@ -72,7 +72,7 @@ public class XomReader extends AbstractDocumentReader {
     @Override
     public String getValue() {
         // currentElement.getValue() not used as this includes text of child elements, which we don't want.
-        final StringBuffer result = new StringBuffer();
+        final StringBuilder result = new StringBuilder();
         final int childCount = currentElement.getChildCount();
         for (int i = 0; i < childCount; i++) {
             final Node child = currentElement.getChild(i);


### PR DESCRIPTION
https://github.com/x-stream/xstream/issues/298
https://jenkins.updater.j2eeguys.com/
Use Charsequence and StringBuilder rather than StringBuffer from Sanddusttx
xstream/src/java/com/thoughtworks/xstream/core/util/FastStack.java
    Replace the synchronized class "StringBuffer" by an unsynchronized one such as "StringBuilder". [java:S1149]
xstream/src/java/com/thoughtworks/xstream/io/path/PathTracker.java
    Replace the synchronized class "StringBuffer" by an unsynchronized one such as "StringBuilder". [java:S1149]
xstream/src/java/com/thoughtworks/xstream/io/xml/AbstractPullReader.java
    Replace the synchronized class "StringBuffer" by an unsynchronized one such as "StringBuilder". [java:S1149]
xstream/src/java/com/thoughtworks/xstream/io/xml/XomReader.java
    Replace the synchronized class "StringBuffer" by an unsynchronized one such as "StringBuilder". [java:S1149]
xstream-benchmark/src/java/com/thoughtworks/xstream/tools/benchmark/reporters/HtmlReporter.java
    Replace the synchronized class "StringBuffer" by an unsynchronized one such as "StringBuilder". [java:S1149]
xstream/src/java/com/thoughtworks/xstream/io/xml/XmlFriendlyNameCoder.java
    Replace the synchronized class "StringBuffer" by an unsynchronized one such as "StringBuilder". [java:S1149]
xstream/src/java/com/thoughtworks/xstream/core/util/XmlHeaderAwareReader.java
    Replace the synchronized class "StringBuffer" by an unsynchronized one such as "StringBuilder". [java:S1149]
xstream-benchmark/src/java/com/thoughtworks/xstream/tools/benchmark/reporters/TextReporter.java
    Replace the synchronized class "StringBuffer" by an unsynchronized one such as "StringBuilder". [java:S1149]
xstream/src/java/com/thoughtworks/xstream/io/xml/DomDriver.java
    Disable access to external entities in XML parsing. [java:S2755]
