### PR TITLE
Unable to serialize `AtomicBoolean` on Java 17

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/XStream.java
+++ b/xstream/src/java/com/thoughtworks/xstream/XStream.java
@@ -101,6 +101,7 @@ import java.util.TreeSet;
 import java.util.UUID;
 import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
 import com.thoughtworks.xstream.converters.ConversionException;
@@ -141,6 +142,7 @@ import com.thoughtworks.xstream.converters.collections.TreeSetConverter;
 import com.thoughtworks.xstream.converters.enums.EnumConverter;
 import com.thoughtworks.xstream.converters.enums.EnumMapConverter;
 import com.thoughtworks.xstream.converters.enums.EnumSetConverter;
+import com.thoughtworks.xstream.converters.extended.AtomicBooleanConverter;
 import com.thoughtworks.xstream.converters.extended.CharsetConverter;
 import com.thoughtworks.xstream.converters.extended.ColorConverter;
 import com.thoughtworks.xstream.converters.extended.CurrencyConverter;
@@ -710,7 +712,7 @@ public class XStream {
         allowTypeHierarchy(Path.class);
 
         final Set<Class<?>> types = new HashSet<>();
-        types.addAll(Arrays.<Class<?>>asList(BitSet.class, Charset.class, Class.class, Currency.class, Date.class,
+        types.addAll(Arrays.<Class<?>>asList(AtomicBoolean.class, BitSet.class, Charset.class, Class.class, Currency.class, Date.class,
             DecimalFormatSymbols.class, File.class, Locale.class, Object.class, Pattern.class, StackTraceElement.class,
             String.class, StringBuffer.class, StringBuilder.class, URL.class, URI.class, UUID.class));
         if (JVM.isSQLAvailable()) {
@@ -996,6 +998,7 @@ public class XStream {
         registerConverter(new JavaMethodConverter(classLoaderReference), PRIORITY_NORMAL);
         registerConverter(new JavaFieldConverter(classLoaderReference), PRIORITY_NORMAL);
         registerConverter(new LambdaConverter(mapper, reflectionProvider, classLoaderReference), PRIORITY_NORMAL);
+        registerConverter(new AtomicBooleanConverter(), PRIORITY_NORMAL);
 
         if (JVM.isAWTAvailable()) {
             registerConverter(new FontConverter(mapper), PRIORITY_NORMAL);

--- a/xstream/src/java/com/thoughtworks/xstream/converters/extended/AtomicBooleanConverter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/extended/AtomicBooleanConverter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 XStream Committers.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ * Created on 9 September 2022 by Basil Crow.
+ */
+package com.thoughtworks.xstream.converters.extended;
+
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.SingleValueConverterWrapper;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.converters.basic.BooleanConverter;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/** Converts an {@link AtomicBoolean}. */
+public class AtomicBooleanConverter implements Converter {
+
+    @Override
+    public boolean canConvert(Class<?> type) {
+        return type != null && AtomicBoolean.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public void marshal(
+            Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
+        final AtomicBoolean atomicBoolean = (AtomicBoolean) source;
+        writer.startNode("value");
+        context.convertAnother(
+                atomicBoolean.get(), new SingleValueConverterWrapper(BooleanConverter.BINARY));
+        writer.endNode();
+    }
+
+    @Override
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+        reader.moveDown();
+        Object item =
+                context.convertAnother(
+                        null,
+                        Boolean.class,
+                        new SingleValueConverterWrapper(BooleanConverter.BINARY));
+        boolean value = item instanceof Boolean ? ((Boolean) item).booleanValue() : false;
+        reader.moveUp();
+        return new AtomicBoolean(value);
+    }
+}

--- a/xstream/src/test/com/thoughtworks/xstream/converters/extended/AtomicBooleanFieldsTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/converters/extended/AtomicBooleanFieldsTest.java
@@ -1,0 +1,49 @@
+package com.thoughtworks.xstream.converters.extended;
+
+import com.thoughtworks.acceptance.AbstractAcceptanceTest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class AtomicBooleanFieldsTest extends AbstractAcceptanceTest {
+
+    public static class Musican {
+        public String name;
+        public String genre;
+        public AtomicBoolean alive;
+
+        public Musican(final String name, final String genre, final AtomicBoolean alive) {
+            this.name = name;
+            this.genre = genre;
+            this.alive = alive;
+        }
+    }
+
+    public void testAtomicBooleanFields() {
+        final List<Musican> jazzIcons = new ArrayList<>();
+        jazzIcons.add(new Musican("Miles Davis", "jazz", new AtomicBoolean(false)));
+        jazzIcons.add(new Musican("Wynton Marsalis", "jazz", new AtomicBoolean(true)));
+
+        xstream.alias("musician", Musican.class);
+
+        final String expectedXml =
+                "<list>\n"
+                        + "  <musician>\n"
+                        + "    <name>Miles Davis</name>\n"
+                        + "    <genre>jazz</genre>\n"
+                        + "    <alive>\n"
+                        + "      <value>0</value>\n"
+                        + "    </alive>\n"
+                        + "  </musician>\n"
+                        + "  <musician>\n"
+                        + "    <name>Wynton Marsalis</name>\n"
+                        + "    <genre>jazz</genre>\n"
+                        + "    <alive>\n"
+                        + "      <value>1</value>\n"
+                        + "    </alive>\n"
+                        + "  </musician>\n"
+                        + "</list>";
+
+        assertBothWays(jazzIcons, expectedXml);
+    }
+}


### PR DESCRIPTION
This is my first attempt at submitting a pull request to XStream, so please let me know if there is anything different I should be doing. I am not sure if this is the right approach to take, so I am posting this in hopes that someone can point me in a better direction if this is wrong.

This PR fixes #308. I took a wild guess as to how it should be implemented.

With the changes to `xstream/src/java/` reverted (i.e., at commit 61e0eade), the new test passes on Java 8 and Java 11 but fails on Java 17.

With the changes to `xstream/src/java/` present (i.e., at commit commit 36b30bea), the new test passes on Java 8, Java 11, and Java 17.