### PR TITLE
Fix AtomicReference marshalling. Closes #326

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/converters/extended/AtomicReferenceConverter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/extended/AtomicReferenceConverter.java
@@ -41,13 +41,13 @@ public class AtomicReferenceConverter implements Converter {
 
     public void marshal(final Object source, final HierarchicalStreamWriter writer, final MarshallingContext context) {
         final AtomicReference ref = (AtomicReference)source;
-        if (ref.get() != null) {
+        final Object object = ref.get();
+        if (object != null) {
             writer.startNode(mapper.serializedMember(AtomicReference.class, "value"));
 
-            final Object object = ref.get();
-            final String name = mapper.serializedClass(object != null ? object.getClass() : null);
+            final String name = mapper.serializedClass(object.getClass());
             writer.addAttribute(mapper.aliasForSystemAttribute("class"), name);
-            context.convertAnother(ref.get());
+            context.convertAnother(object);
             writer.endNode();
         }
     }

--- a/xstream/src/java/com/thoughtworks/xstream/converters/extended/AtomicReferenceConverter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/extended/AtomicReferenceConverter.java
@@ -40,23 +40,29 @@ public class AtomicReferenceConverter implements Converter {
     }
 
     public void marshal(final Object source, final HierarchicalStreamWriter writer, final MarshallingContext context) {
-        final AtomicReference ref = (AtomicReference)source; 
-        writer.startNode(mapper.serializedMember(AtomicReference.class, "value"));
+        final AtomicReference ref = (AtomicReference)source;
+        if (ref.get() != null) {
+            writer.startNode(mapper.serializedMember(AtomicReference.class, "value"));
 
-        final Object object = ref.get();
-        final String name = mapper.serializedClass(object!= null ? object.getClass() : null);
-        writer.addAttribute(mapper.aliasForSystemAttribute("class"), name);
-        context.convertAnother(ref.get());
-        writer.endNode();
+            final Object object = ref.get();
+            final String name = mapper.serializedClass(object != null ? object.getClass() : null);
+            writer.addAttribute(mapper.aliasForSystemAttribute("class"), name);
+            context.convertAnother(ref.get());
+            writer.endNode();
+        }
     }
 
     public Object unmarshal(final HierarchicalStreamReader reader, final UnmarshallingContext context) {
-        reader.moveDown();
+        if (reader.hasMoreChildren()) {
+            reader.moveDown();
 
-        final Class type = HierarchicalStreams.readClassType(reader, mapper);
-        final Object value = context.convertAnother(context, type);
-        reader.moveUp();
-        return new AtomicReference(value);
+            final Class type = HierarchicalStreams.readClassType(reader, mapper);
+            final Object value = context.convertAnother(context, type);
+            reader.moveUp();
+            return new AtomicReference(value);
+        } else {
+            return new AtomicReference();
+        }
     }
 
 }

--- a/xstream/src/test/com/thoughtworks/acceptance/Concurrent15TypesTest.java
+++ b/xstream/src/test/com/thoughtworks/acceptance/Concurrent15TypesTest.java
@@ -117,6 +117,11 @@ public class Concurrent15TypesTest extends AbstractAcceptanceTest {
             + "</java.util.concurrent.atomic.AtomicReference>")).get());
     }
 
+    public void testEmptyAtomicReference() {
+        final AtomicReference atomicRef = new AtomicReference();
+        assertBothWays(atomicRef, "<atomic-reference/>");
+    }
+
     public void testAtomicReferenceWithAlias() {
         xstream.aliasField("junit", AtomicReference.class, "value");
         final AtomicReference atomicRef = new AtomicReference("test");


### PR DESCRIPTION
This fix will fix NPE when marshalling empty `AtomicReference` objects.