### PR TITLE
QuickWriter: Fix remaining buffer size estimation

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/core/util/QuickWriter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/core/util/QuickWriter.java
@@ -35,7 +35,7 @@ public class QuickWriter implements Closeable {
 
     public void write(final String str) {
         final int len = str.length();
-        if (pointer + len >= buffer.length) {
+        if (pointer + len > buffer.length) {
             flush();
             if (len > buffer.length) {
                 raw(str.toCharArray());
@@ -47,7 +47,7 @@ public class QuickWriter implements Closeable {
     }
 
     public void write(final char c) {
-        if (pointer + 1 >= buffer.length) {
+        if (pointer + 1 > buffer.length) {
             flush();
             if (buffer.length == 0) {
                 raw(c);
@@ -59,7 +59,7 @@ public class QuickWriter implements Closeable {
 
     public void write(final char[] c) {
         final int len = c.length;
-        if (pointer + len >= buffer.length) {
+        if (pointer + len > buffer.length) {
             flush();
             if (len > buffer.length) {
                 raw(c);

--- a/xstream/src/test/com/thoughtworks/xstream/core/util/QuickWriterTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/core/util/QuickWriterTest.java
@@ -31,4 +31,42 @@ public class QuickWriterTest extends TestCase {
             assertEquals(stringWriter.toString(), "Joe Walnes");
         }
     }
+
+    public void testBufferingChar() {
+        final StringWriter stringWriter = new StringWriter();
+        try (QuickWriter writer = new QuickWriter(stringWriter, 1024)) {
+            char[] filler = new char[1023];
+            writer.write(filler);
+            assertEquals("not flushed yet", 0, stringWriter.getBuffer().length());
+            writer.write(' ');
+            assertEquals("not flushed yet", 0, stringWriter.getBuffer().length());
+            writer.write(' ');
+            assertEquals("flushed", 1024, stringWriter.getBuffer().length());
+        }
+    }
+    public void testBufferingCharArray() {
+        final StringWriter stringWriter = new StringWriter();
+        try (QuickWriter writer = new QuickWriter(stringWriter, 1024)) {
+            char[] filler = new char[1023];
+            writer.write(filler);
+            assertEquals("not flushed yet", 0, stringWriter.getBuffer().length());
+            char[] one = {' '};
+            writer.write(one);
+            assertEquals("not flushed yet", 0, stringWriter.getBuffer().length());
+            writer.write(one);
+            assertEquals("flushed", 1024, stringWriter.getBuffer().length());
+        }
+    }
+    public void testBufferingString() {
+        final StringWriter stringWriter = new StringWriter();
+        try (QuickWriter writer = new QuickWriter(stringWriter, 1024)) {
+            char[] filler = new char[1023];
+            writer.write(filler);
+            assertEquals("not flushed yet", 0, stringWriter.getBuffer().length());
+            writer.write(" ");
+            assertEquals("not flushed yet", 0, stringWriter.getBuffer().length());
+            writer.write(" ");
+            assertEquals("flushed", 1024, stringWriter.getBuffer().length());
+        }
+    }
 }


### PR DESCRIPTION
I've noticed oddly sized 1023 byte write events during performance profiling, which was traced back to `write(char)` flushing the buffer before the buffer was full.

QuickWriter seems to incorrectly estimate the remaining size limit by one, 
flushing the buffer early before it is full.
