### PR TITLE
Allow `PrettyPrintWriter` to replace invalid XML characters when not running in quirks mode

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/io/xml/PrettyPrintWriter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/io/xml/PrettyPrintWriter.java
@@ -42,6 +42,8 @@ import com.thoughtworks.xstream.io.naming.NameCoder;
  * href="http://www.w3.org/TR/2006/REC-xml11-20060816/#charsets">1.1</a>. If a character is not supported, a
  * {@link StreamException} is thrown. Select a proper parser implementation that respects the version in the XML header
  * (the Xpp3 parser will also read character entities of normally invalid characters).
+ * You may also switch to XML_1_0_REPLACEMENT or XML_1_1_REPLACEMENT mode, which will replace the invalid characters
+ * with a U+FFFD replacement character.
  * </p>
  * 
  * @author Joe Walnes
@@ -52,6 +54,8 @@ public class PrettyPrintWriter extends AbstractXmlWriter {
     public static int XML_QUIRKS = -1;
     public static int XML_1_0 = 0;
     public static int XML_1_1 = 1;
+    public static int XML_1_0_REPLACEMENT = 2;
+    public static int XML_1_1_REPLACEMENT = 3;
 
     private final QuickWriter writer;
     private final FastStack<String> elementStack = new FastStack<>(16);
@@ -71,6 +75,7 @@ public class PrettyPrintWriter extends AbstractXmlWriter {
     private static final char[] QUOT = "&quot;".toCharArray();
     private static final char[] APOS = "&apos;".toCharArray();
     private static final char[] CLOSE = "</".toCharArray();
+    private static final char[] REPLACEMENT = "&#xfffd;".toCharArray();
 
     /**
      * @since 1.4
@@ -80,8 +85,8 @@ public class PrettyPrintWriter extends AbstractXmlWriter {
         this.writer = new QuickWriter(writer);
         this.lineIndenter = lineIndenter;
         this.mode = mode;
-        if (mode < XML_QUIRKS || mode > XML_1_1) {
-            throw new IllegalArgumentException("Not a valid XML mode");
+        if (mode < XML_QUIRKS || mode > XML_1_1_REPLACEMENT) {
+            throw new IllegalArgumentException("Not a valid XML mode: " + mode);
         }
     }
 
@@ -213,6 +218,8 @@ public class PrettyPrintWriter extends AbstractXmlWriter {
             case '\0':
                 if (mode == XML_QUIRKS) {
                     writer.write(NULL);
+                } else if (mode == XML_1_0_REPLACEMENT || mode == XML_1_1_REPLACEMENT) {
+                    writer.write(REPLACEMENT);
                 } else {
                     throw new StreamException("Invalid character 0x0 in XML stream");
                 }
@@ -244,32 +251,53 @@ public class PrettyPrintWriter extends AbstractXmlWriter {
                 //$FALL-THROUGH$
             default:
                 if (Character.isDefined(c) && !Character.isISOControl(c)) {
+                    boolean replaced = false;
                     if (mode != XML_QUIRKS) {
                         if (c > '\ud7ff' && c < '\ue000') {
-                            throw new StreamException("Invalid character 0x"
-                                + Integer.toHexString(c)
-                                + " in XML stream");
+                            if (mode == XML_1_0_REPLACEMENT || mode == XML_1_1_REPLACEMENT) {
+                                writer.write(REPLACEMENT);
+                                replaced = true;
+                            } else {
+                                throw new StreamException("Invalid character 0x"
+                                        + Integer.toHexString(c)
+                                        + " in XML stream");
+                            }
                         }
                     }
-                    writer.write(c);
+                    if (!replaced) {
+                        writer.write(c);
+                    }
                 } else {
-                    if (mode == XML_1_0) {
+                    boolean replaced = false;
+                    if (mode == XML_1_0 || mode == XML_1_0_REPLACEMENT) {
                         if (c < 9 || c == '\u000b' || c == '\u000c' || c == '\u000e' || c >= '\u000f' && c <= '\u001f') {
-                            throw new StreamException("Invalid character 0x"
-                                + Integer.toHexString(c)
-                                + " in XML 1.0 stream");
+                            if (mode == XML_1_0_REPLACEMENT) {
+                                writer.write(REPLACEMENT);
+                                replaced = true;
+                            } else {
+                                throw new StreamException("Invalid character 0x"
+                                        + Integer.toHexString(c)
+                                        + " in XML 1.0 stream");
+                            }
                         }
                     }
                     if (mode != XML_QUIRKS) {
                         if (c == '\ufffe' || c == '\uffff') {
-                            throw new StreamException("Invalid character 0x"
-                                + Integer.toHexString(c)
-                                + " in XML stream");
+                            if (mode == XML_1_0_REPLACEMENT || mode == XML_1_1_REPLACEMENT) {
+                                writer.write(REPLACEMENT);
+                                replaced = true;
+                            } else {
+                                throw new StreamException("Invalid character 0x"
+                                        + Integer.toHexString(c)
+                                        + " in XML stream");
+                            }
                         }
                     }
-                    writer.write("&#x");
-                    writer.write(Integer.toHexString(c));
-                    writer.write(';');
+                    if (!replaced) {
+                        writer.write("&#x");
+                        writer.write(Integer.toHexString(c));
+                        writer.write(';');
+                    }
                 }
             }
         }

--- a/xstream/src/test/com/thoughtworks/xstream/io/xml/PrettyPrintWriterTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/io/xml/PrettyPrintWriterTest.java
@@ -168,6 +168,24 @@ public class PrettyPrintWriterTest extends AbstractXMLWriterTest {
         }
     }
 
+    public void testReplacesNullInXml1_0ReplacementMode() {
+        writer = new PrettyPrintWriter(buffer, PrettyPrintWriter.XML_1_0_REPLACEMENT);
+        writer.startNode("tag");
+        writer.setValue("\u0000");
+        writer.endNode();
+
+        assertXmlProducedIs("<tag>&#xfffd;</tag>");
+    }
+
+    public void testReplacesNullInXml1_1ReplacementMode() {
+        writer = new PrettyPrintWriter(buffer, PrettyPrintWriter.XML_1_1_REPLACEMENT);
+        writer.startNode("tag");
+        writer.setValue("\u0000");
+        writer.endNode();
+
+        assertXmlProducedIs("<tag>&#xfffd;</tag>");
+    }
+
     public void testSupportsOnlyValidControlCharactersInXml1_0Mode() {
         writer = new PrettyPrintWriter(buffer, PrettyPrintWriter.XML_1_0);
         writer.startNode("tag");
@@ -237,6 +255,65 @@ public class PrettyPrintWriterTest extends AbstractXMLWriterTest {
             + "&#x98;&#x99;&#x9a;&#x9b;&#x9c;&#x9d;&#x9e;&#x9f;</tag>");
     }
 
+    public void testReplacesInvalidControlCharactersInXml1_0ReplacementMode() {
+        writer = new PrettyPrintWriter(buffer, PrettyPrintWriter.XML_1_0_REPLACEMENT);
+        writer.startNode("tag");
+        final String ctrl = ""
+                + "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007"
+                + "\u0008\u0009\n\u000b\u000c\r\u000e\u000f"
+                + "\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017"
+                + "\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f"
+                + "\u007f"
+                + "\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087"
+                + "\u0088\u0089\u008a\u008b\u008c\u008d\u008e\u008f"
+                + "\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097"
+                + "\u0098\u0099\u009a\u009b\u009c\u009d\u009e\u009f"
+                + "";
+        for (int i = 0; i < ctrl.length(); i++) {
+            final char c = ctrl.charAt(i);
+            writer.setValue(new Character(c).toString());
+        }
+        writer.endNode();
+
+        assertXmlProducedIs("<tag>&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;"
+                + "&#xfffd;\t\n&#xfffd;&#xfffd;&#xd;&#xfffd;&#xfffd;"
+                + "&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;"
+                + "&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;"
+                + "&#x7f;"
+                + "&#x80;&#x81;&#x82;&#x83;&#x84;&#x85;&#x86;&#x87;"
+                + "&#x88;&#x89;&#x8a;&#x8b;&#x8c;&#x8d;&#x8e;&#x8f;"
+                + "&#x90;&#x91;&#x92;&#x93;&#x94;&#x95;&#x96;&#x97;"
+                + "&#x98;&#x99;&#x9a;&#x9b;&#x9c;&#x9d;&#x9e;&#x9f;</tag>");    }
+
+    public void testReplacesInvalidControlCharactersInXml1_1ReplacementMode() {
+        writer = new PrettyPrintWriter(buffer, PrettyPrintWriter.XML_1_1_REPLACEMENT);
+        writer.startNode("tag");
+        final String ctrl = ""
+                + "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007"
+                + "\u0008\u0009\n\u000b\u000c\r\u000e\u000f"
+                + "\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017"
+                + "\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f"
+                + "\u007f"
+                + "\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087"
+                + "\u0088\u0089\u008a\u008b\u008c\u008d\u008e\u008f"
+                + "\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097"
+                + "\u0098\u0099\u009a\u009b\u009c\u009d\u009e\u009f"
+                + "";
+        for (int i = 0; i < ctrl.length(); i++) {
+            final char c = ctrl.charAt(i);
+            writer.setValue(new Character(c).toString());
+        }
+        writer.endNode();
+        assertXmlProducedIs("<tag>&#xfffd;&#x1;&#x2;&#x3;&#x4;&#x5;&#x6;&#x7;"
+                + "&#x8;\t\n&#xb;&#xc;&#xd;&#xe;&#xf;"
+                + "&#x10;&#x11;&#x12;&#x13;&#x14;&#x15;&#x16;&#x17;"
+                + "&#x18;&#x19;&#x1a;&#x1b;&#x1c;&#x1d;&#x1e;&#x1f;&#x7f;"
+                + "&#x80;&#x81;&#x82;&#x83;&#x84;&#x85;&#x86;&#x87;"
+                + "&#x88;&#x89;&#x8a;&#x8b;&#x8c;&#x8d;&#x8e;&#x8f;"
+                + "&#x90;&#x91;&#x92;&#x93;&#x94;&#x95;&#x96;&#x97;"
+                + "&#x98;&#x99;&#x9a;&#x9b;&#x9c;&#x9d;&#x9e;&#x9f;</tag>");
+    }
+
     public void testSupportsInvalidUnicodeCharacterslInQuirksMode() {
         writer = new PrettyPrintWriter(buffer, PrettyPrintWriter.XML_QUIRKS);
         writer.startNode("tag");
@@ -293,6 +370,30 @@ public class PrettyPrintWriterTest extends AbstractXMLWriterTest {
         }
         writer.endNode();
         assertXmlProducedIs("<tag>&#xd7ff;\ue000\ufffd</tag>");
+    }
+
+    public void testReplacesInvalidUnicodeCharactersInXml1_0ReplacementMode() {
+        writer = new PrettyPrintWriter(buffer, PrettyPrintWriter.XML_1_0_REPLACEMENT);
+        writer.startNode("tag");
+        final String ctrl = "\ud7ff\ud800\udfff\ue000\ufffd\ufffe\uffff";
+        for (int i = 0; i < ctrl.length(); i++) {
+            final char c = ctrl.charAt(i);
+            writer.setValue(new Character(c).toString());
+        }
+        writer.endNode();
+        assertXmlProducedIs("<tag>&#xd7ff;&#xfffd;&#xfffd;\ue000\ufffd&#xfffd;&#xfffd;</tag>");
+    }
+
+    public void testReplacesInvalidUnicodeCharactersInXml1_1ReplacementMode() {
+        writer = new PrettyPrintWriter(buffer, PrettyPrintWriter.XML_1_1_REPLACEMENT);
+        writer.startNode("tag");
+        final String ctrl = "\ud7ff\ud800\udfff\ue000\ufffd\ufffe\uffff";
+        for (int i = 0; i < ctrl.length(); i++) {
+            final char c = ctrl.charAt(i);
+            writer.setValue(new Character(c).toString());
+        }
+        writer.endNode();
+        assertXmlProducedIs("<tag>&#xd7ff;&#xfffd;&#xfffd;\ue000\ufffd&#xfffd;&#xfffd;</tag>");
     }
 
     private String replace(final String in, final char what, final String with) {


### PR DESCRIPTION
From https://github.com/jenkinsci/jenkins/pull/7875:

> For a general defense, `PrettyPrintWriter.writeText` (and `.writeAttributeValue`) could quietly replace NULs with some placeholder such as ^@ and not pretend to round-trip them.

This PR offers an alternative to quirks mode ("replacement mode") for XML 1.0 and XML 1.1 serialization that replaces invalid characters with the [U+FFFD � replacement character](https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character), thus ensuring that the XML written out by `PrettyPrintWriter` is always valid XML 1.0 or XML 1.1 without forcing consumers to sanitize their input.