### PR TITLE
`PrettyPrintWriter` fails to serialize characters in the Unicode Supplementary Multilingual Plane in XML 1.0 mode and XML 1.1 mode

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/io/xml/PrettyPrintWriter.java
+++ b/xstream/src/java/com/thoughtworks/xstream/io/xml/PrettyPrintWriter.java
@@ -206,9 +206,7 @@ public class PrettyPrintWriter extends AbstractXmlWriter {
     }
 
     private void writeText(final String text, final boolean isAttribute) {
-        final int length = text.length();
-        for (int i = 0; i < length; i++) {
-            final char c = text.charAt(i);
+        text.codePoints().forEach(c -> {
             switch (c) {
             case '\0':
                 if (mode == XML_QUIRKS) {
@@ -238,7 +236,7 @@ public class PrettyPrintWriter extends AbstractXmlWriter {
             case '\t':
             case '\n':
                 if (!isAttribute) {
-                    writer.write(c);
+                    writer.write(Character.toChars(c));
                     break;
                 }
                 //$FALL-THROUGH$
@@ -251,7 +249,7 @@ public class PrettyPrintWriter extends AbstractXmlWriter {
                                 + " in XML stream");
                         }
                     }
-                    writer.write(c);
+                    writer.write(Character.toChars(c));
                 } else {
                     if (mode == XML_1_0) {
                         if (c < 9 || c == '\u000b' || c == '\u000c' || c == '\u000e' || c >= '\u000f' && c <= '\u001f') {
@@ -272,7 +270,7 @@ public class PrettyPrintWriter extends AbstractXmlWriter {
                     writer.write(';');
                 }
             }
-        }
+        });
     }
 
     @Override

--- a/xstream/src/test/com/thoughtworks/xstream/io/xml/PrettyPrintWriterTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/io/xml/PrettyPrintWriterTest.java
@@ -295,6 +295,33 @@ public class PrettyPrintWriterTest extends AbstractXMLWriterTest {
         assertXmlProducedIs("<tag>&#xd7ff;\ue000\ufffd</tag>");
     }
 
+    public void testSupportsSupplementaryMultilingualPlaneInQuirks_Mode() {
+        writer = new PrettyPrintWriter(buffer, PrettyPrintWriter.XML_QUIRKS);
+        writer.startNode("tag");
+        writer.setValue("\uD83E\uDD8A");
+        writer.endNode();
+
+        assertXmlProducedIs("<tag>\uD83E\uDD8A</tag>");
+    }
+
+    public void testSupportsSupplementaryMultilingualPlaneInXml1_0Mode() {
+        writer = new PrettyPrintWriter(buffer, PrettyPrintWriter.XML_1_0);
+        writer.startNode("tag");
+        writer.setValue("\uD83E\uDD8A");
+        writer.endNode();
+
+        assertXmlProducedIs("<tag>\uD83E\uDD8A</tag>");
+    }
+
+    public void testSupportsSupplementaryMultilingualPlaneInXml1_1Mode() {
+        writer = new PrettyPrintWriter(buffer, PrettyPrintWriter.XML_1_1);
+        writer.startNode("tag");
+        writer.setValue("\uD83E\uDD8A");
+        writer.endNode();
+
+        assertXmlProducedIs("<tag>\uD83E\uDD8A</tag>");
+    }
+
     private String replace(final String in, final char what, final String with) {
         final int pos = in.indexOf(what);
         if (pos == -1) {


### PR DESCRIPTION
`PrettyPrintWriter` fails to properly serialize characters in the Unicode Supplementary Multilingual Plane (SMP) in XML 1.0 mode and XML 1.1 mode (quirks mode works) with the following exception:

```
com.thoughtworks.xstream.io.StreamException: Invalid character 0xd83e in XML stream
        at com.thoughtworks.xstream.io.xml.PrettyPrintWriter.writeText(PrettyPrintWriter.java:250)
        at com.thoughtworks.xstream.io.xml.PrettyPrintWriter.writeText(PrettyPrintWriter.java:205)
        at com.thoughtworks.xstream.io.xml.PrettyPrintWriter.setValue(PrettyPrintWriter.java:187)
        at com.thoughtworks.xstream.io.xml.PrettyPrintWriterTest.testSupportsSupplementaryMultilingualPlaneInXml1_0Mode(PrettyPrintWriterTest.java:310)
```

The root cause of the problem is incorrect iteration over Unicode code points. The current implementation iterates over the UTF-16 representation of the characters rather than iterating over each code point. Characters in the Supplementary Multilingual Plane are encoded in UTF-16 as two digits. For example U+1F98A is encoded in UTF-16 as 0xD83E 0xDD8A. Java provides a dedicated API to iterate over code points, but XStream makes the erroneous assumption that a code point and a character are equivalent, likely because it was never tested outside of quirks mode with characters in the Supplementary Multilingual Plane. This PR fixes the problem by using the Java API for iterating over code points, thus removing the faulty assumption that a code point and a character are equivalent.

The new quirks mode test passes before and after the changes to `PrettyPrintWriter`. The new XML 1.0 mode and XML 1.1 mode tests fail before the changes to `PrettyPrintWriter` with the exception given above. The new XML 1.0 mode and XML 1.0 mode tests pass after the changes to `PrettyPrintWriter`.

Fixes #336