### PR TITLE
Make Types#isLambdaType work on JDK >= 21

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/core/util/Types.java
+++ b/xstream/src/java/com/thoughtworks/xstream/core/util/Types.java
@@ -16,10 +16,16 @@ import java.util.regex.Pattern;
  * @since 1.4.8
  */
 public class Types {
-    private static final Pattern lambdaPattern = Pattern.compile(".*\\$\\$Lambda\\$[0-9]+/.*");
+    private static final Pattern lambdaPattern = Pattern.compile(".*\\$\\$Lambda(?:\\$[0-9]+|)/.*");
 
     public static final boolean isLambdaType(final Class<?> type) {
-        return type != null && type.isSynthetic() && lambdaPattern.matcher(type.getSimpleName()).matches();
+        if (type != null && type.isSynthetic()) {
+            String typeName = type.getSimpleName();
+            if (typeName.length() == 0) { // JDK >= 17: JDK-8254979 makes getSimpleName() return "" for lambdas
+              typeName = type.getName();
+            }
+            return lambdaPattern.matcher(typeName).matches();
+        }
+        return false;
     }
-
 }

--- a/xstream/src/test/com/thoughtworks/acceptance/LambdaTest.java
+++ b/xstream/src/test/com/thoughtworks/acceptance/LambdaTest.java
@@ -199,8 +199,10 @@ public class LambdaTest extends AbstractAcceptanceTest {
     }
 
     private String normalizeLambda(final String xml) {
-        // unify compiler specific name for implMethodName, Eclipse uses always "lambda$0"
-        return xml.replaceAll(">lambda\\$[^<]+<", ">lambda\\$0<");
+        // unify compiler specific name for implMethodName (Eclipse uses always "lambda$0")
+        // and implMethodKind (varies between at least JDK17 and JDK21 in some cases)
+        return xml.replaceAll( ">lambda\\$[^<]+<", ">lambda\\$0<" )
+            .replaceAll( "<implMethodKind>\\d+</implMethodKind>", "<implMethodKind>5</implMethodKind>" );
     }
 
     public void testTreeSetWithLambda() {


### PR DESCRIPTION
Hi,

After upgrading our application to JDK 21 (Eclipse Temurin) we noticed that serialization was suddenly crashing. An investigation of the generated XML showed that lambda types were no longer being detected correctly (see screenshot, jdk-17 on LHS, jdk-21 on RHS)

![image](https://github.com/x-stream/xstream/assets/271364/b61bcd93-7db3-4f7b-bb06-ed5ec0d2ebbe)

I traced this down to https://bugs.openjdk.org/browse/JDK-8254979 and the code in Types#isLambdaType which only checks Class#getSimpleName.

When trying to execute the tests in LambdaTest.java I realized that at least JDK 21 (Eclipse Temurin) now also generated slightly different classnames for the lambdas in that unit test so I also adjusted the regular expression in Types#isLambdaType to be a bit more fuzzy... looking at https://stackoverflow.com/questions/23870478/how-to-correctly-determine-that-an-object-is-a-lambda , Brian Goetz would not approve of this code anyway ;)

Last but not least, JDK21 uses a different "implMethodKind" value in one case that made a unit test fail so I extended the normalizeLambda() method in LambdaTests.java with another hack. 