### PR TITLE
Memory allocation optimizations

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/converters/reflection/FieldDictionary.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/reflection/FieldDictionary.java
@@ -123,7 +123,16 @@ public class FieldDictionary implements Caching {
 
         Class cls = type;
 
-        DictionaryEntry lastDictionaryEntry = null;
+        DictionaryEntry lastDictionaryEntry;
+        if (Object.class.equals(cls) || cls == null) {
+            lastDictionaryEntry = OBJECT_DICTIONARY_ENTRY;
+        } else {
+            lastDictionaryEntry = getDictionaryEntry(type);
+        }
+        if (lastDictionaryEntry != null) {
+            return tupleKeyed ? lastDictionaryEntry.getKeyedByFieldKey() : lastDictionaryEntry.getKeyedByFieldName();
+        }
+
         final LinkedList superClasses = new LinkedList();
         while (lastDictionaryEntry == null) {
             if (Object.class.equals(cls) || cls == null) {

--- a/xstream/src/java/com/thoughtworks/xstream/converters/reflection/FieldKey.java
+++ b/xstream/src/java/com/thoughtworks/xstream/converters/reflection/FieldKey.java
@@ -19,7 +19,7 @@ package com.thoughtworks.xstream.converters.reflection;
 public class FieldKey {
     final private String fieldName;
     final private Class declaringClass;
-    final private int depth;
+    private int depth = -1;
     final private int order;
 
     public FieldKey(String fieldName, Class declaringClass, int order) {
@@ -29,13 +29,6 @@ public class FieldKey {
         this.fieldName = fieldName;
         this.declaringClass = declaringClass;
         this.order = order;
-        Class c = declaringClass;
-        int i = 0;
-        while (c.getSuperclass() != null) {
-            i++;
-            c = c.getSuperclass();
-        }
-        depth = i;
     }
 
     public String getFieldName() {
@@ -47,6 +40,15 @@ public class FieldKey {
     }
 
     public int getDepth() {
+        if (this.depth == -1) {
+            Class c = declaringClass;
+            int i = 0;
+            while (c.getSuperclass() != null) {
+                i++;
+                c = c.getSuperclass();
+            }
+            this.depth = i;
+        }
         return this.depth;
     }
 
@@ -80,7 +82,7 @@ public class FieldKey {
             + "order="
             + order
             + ", writer="
-            + depth
+            + getDepth()
             + ", declaringClass="
             + declaringClass
             + ", fieldName='"

--- a/xstream/src/java/com/thoughtworks/xstream/mapper/LocalConversionMapper.java
+++ b/xstream/src/java/com/thoughtworks/xstream/mapper/LocalConversionMapper.java
@@ -12,7 +12,6 @@ package com.thoughtworks.xstream.mapper;
 
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.SingleValueConverter;
-import com.thoughtworks.xstream.core.util.FastField;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -26,7 +25,7 @@ import java.util.Map;
  */
 public class LocalConversionMapper extends MapperWrapper {
 
-    private final Map localConverters = new HashMap();
+    private final Map/*<String, Map<String, Converter>>*/ localConverters = new HashMap();
     private transient AttributeMapper attributeMapper;
 
     /**
@@ -41,11 +40,20 @@ public class LocalConversionMapper extends MapperWrapper {
     }
 
     public void registerLocalConverter(Class definedIn, String fieldName, Converter converter) {
-        localConverters.put(new FastField(definedIn, fieldName), converter);
+        String definedInName = definedIn == null ? null : definedIn.getName();
+        Map fieldConverterMap = (Map) localConverters.get(definedInName);
+        if (fieldConverterMap == null) {
+            fieldConverterMap = new HashMap();
+            localConverters.put(definedInName, fieldConverterMap);
+        }
+        fieldConverterMap.put(fieldName, converter);
     }
 
     public Converter getLocalConverter(Class definedIn, String fieldName) {
-        return (Converter)localConverters.get(new FastField(definedIn, fieldName));
+        String definedInName = definedIn == null ? null : definedIn.getName();
+        Map fieldConverterMap = (Map) localConverters.get(definedInName);
+        if (fieldConverterMap == null) return null;
+        return (Converter) fieldConverterMap.get(fieldName);
     }
 
     public SingleValueConverter getConverterFromAttribute(Class definedIn, String attribute,


### PR DESCRIPTION
While processing several memory dumps and allocation reports, I've spotted significant amount of `FieldKey`, `FastField`, `LinkedList` and `LinkedList$Itr` objects.

It seems most of them are on-time used in some check.
So here are three commits, each one fixes usage of one of the aforementioned classes.

Targeting branch `v-1.4.x`, as we've using it on our fork, and it could be beneficial to other xstream users. Feel free to cherry-pick to `master` branch as well.